### PR TITLE
Add Auth context, login page and session checks

### DIFF
--- a/app/[locale]/dashboard/layout.tsx
+++ b/app/[locale]/dashboard/layout.tsx
@@ -1,13 +1,46 @@
 import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation'; // Importante para la redirección
 import Sidebar from "@/components/Sidebar";
 import Header from "@/components/Header";
-import { SidebarProvider } from "@/context/SidebarContext"; // <--- Mira esta ruta
+import { SidebarProvider } from "@/context/SidebarContext";
 import DashboardContent from "../../../components/DashboardContent";
 
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
     const cookieStore = await cookies();
+    
+    // 1. Intentamos obtener el token de las cookies
+    const token = cookieStore.get('auth_token')?.value;
     const initialCollapsed = cookieStore.get('sidebar_collapsed')?.value === 'true';
 
+    // 2. Si no hay token, fuera. Ni siquiera cargamos el resto.
+    if (!token) {
+        redirect('/login');
+    }
+
+    // 3. (Opcional pero recomendado) Validar el token en el servidor
+    // Esto evita que alguien con un token falso o expirado vea el dashboard
+    try {
+        const response = await fetch("http://127.0.0.1:8000/auth/me", {
+            method: 'GET',
+            headers: {
+                'Authorization': `Bearer ${token}`,
+                'Accept': 'application/json'
+            },
+            // Cache: 'no-store' asegura que siempre verifique contra el servidor
+            cache: 'no-store' 
+        });
+
+        if (!response.ok) {
+            // Si el backend dice que el token no vale (401), redirigimos
+            redirect('/login');
+        }
+    } catch (error) {
+        // Si el servidor de Python está caído, podrías redirigir o mostrar un error
+        console.error("Error validando token en el servidor:", error);
+        redirect('/login');
+    }
+
+    // 4. Si todo está OK, renderizamos el layout normalmente
     return (
         <SidebarProvider initialCollapsed={initialCollapsed}>
             <div className="min-h-screen bg-gray-50">

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -4,7 +4,8 @@ import { NextIntlClientProvider } from 'next-intl';
 import { getMessages } from 'next-intl/server';
 import { notFound } from 'next/navigation';
 import { routing } from '@/i18n/routing';
-import "../globals.css"; // Ojo a la ruta, ahora que bajaste un nivel puede que sea '../globals.css' o '@/app/globals.css'
+import { AuthProvider } from '@/context/AuthContext'; // <--- IMPORTANTE: Importa tu AuthProvider
+import "../globals.css";
 
 const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
 const geistMono = Geist_Mono({ variable: "--font-geist-mono", subsets: ["latin"] });
@@ -35,9 +36,13 @@ export default async function RootLayout({
   return (
     <html lang={locale}>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        {/* El proveedor oficial de next-intl */}
         <NextIntlClientProvider messages={messages}>
-          {children}
+          {/* Envolvemos los children con el AuthProvider. 
+              Ahora TODA la aplicación tiene acceso al usuario logueado 
+          */}
+          <AuthProvider>
+            {children}
+          </AuthProvider>
         </NextIntlClientProvider>
       </body>
     </html>

--- a/app/[locale]/login/page.tsx
+++ b/app/[locale]/login/page.tsx
@@ -1,0 +1,154 @@
+"use client"
+import { useState, useEffect } from 'react';
+import { useTranslations } from 'next-intl';
+import { useRouter } from '@/i18n/routing';
+import AuthLayout from "@/components/AuthLayout";
+import InputField from "@/components/InputField";
+import SubmitButton from "@/components/SubmitButton";
+import Cookies from 'js-cookie';
+import { useAuth } from '@/context/AuthContext';
+
+export default function Login() {
+  const t = useTranslations('auth');
+  const router = useRouter();
+  const { loginGlobal, user, loading: authLoading } = useAuth();
+
+  const [formData, setFormData] = useState({ email: '', password: '' });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (user && !authLoading) {
+      router.push("/dashboard");
+    }
+  }, [user, authLoading, router]);
+
+  // --- LÓGICA DE VALIDACIÓN ---
+  const validateForm = () => {
+    const { email, password } = formData;
+
+    if (!email.trim() || !password.trim()) {
+      setError(t('errors.emptyFields'));
+      return false;
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      setError(t('errors.invalidEmail'));
+      return false;
+    }
+
+    if (password.length < 8) {
+      setError(t('errors.passwordTooShort'));
+      return false;
+    }
+
+    return true;
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+    if (error) setError(null);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!validateForm()) return;
+
+      setLoading(true);
+      setError(null);
+
+      try {
+          const response = await fetch(`http://127.0.0.1:8000/auth/login`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(formData),
+          });
+
+          const data = await response.json();
+
+          if (!response.ok) {
+              if (response.status === 401) throw new Error(t('errors.badCredentials'));
+              throw new Error(data.detail || t('errors.generic'));
+          }
+
+          const expireTime = 30 / (24 * 60); 
+          Cookies.set('auth_token', data.access_token, { expires: expireTime, secure: true, sameSite: 'strict' });
+          
+          await loginGlobal(data.access_token);
+          router.push("/dashboard");
+
+      } catch (err: any) {
+          setError(err.message);
+      } finally {
+          setLoading(false);
+      }
+  };
+
+  const emailIcon = (color: string) => (
+    <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+    </svg>
+  );
+
+  const lockIcon = (color: string) => (
+    <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="3" y="11" width="18" height="11" rx="2" />
+      <path d="M7 11V7a5 5 0 0110 0v4" />
+    </svg>
+  );
+
+  return (
+    <AuthLayout>
+      <div className="h-px bg-blue-50 mb-8" />
+      
+      {error && (
+        <div className="mb-6 p-4 text-sm text-red-600 bg-red-50 rounded-2xl border border-red-100 flex items-center gap-2 animate-shake">
+          <svg className="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          {error}
+        </div>
+      )}
+
+      <form className="space-y-5" onSubmit={handleSubmit} noValidate>
+        <InputField
+          label={t('emailLabel')}
+          type="email"
+          name="email"
+          value={formData.email}
+          onChange={handleChange}
+          placeholder={t('emailPlaceholder')}
+          icon={emailIcon}
+          required
+        />
+        <InputField
+          label={t('passwordLabel')}
+          type="password"
+          name="password"
+          value={formData.password}
+          onChange={handleChange}
+          placeholder={t('passwordPlaceholder')}
+          icon={lockIcon}
+          required
+        />
+        <div className="pt-2">
+          <SubmitButton disabled={loading || authLoading}>
+            {loading ? t('loading') : t('signIn')}
+          </SubmitButton>
+        </div>
+      </form>
+
+      {/* --- BOTÓN PARA REGISTRARSE --- */}
+      <p className="text-center text-gray-400 text-xs mt-8">
+        {t('dontHaveAccount')}{" "}
+        <span
+          onClick={() => router.push("/register")}
+          className="text-blue-600 font-bold hover:underline cursor-pointer transition-all"
+        >
+          {t('register')}
+        </span>
+      </p>
+    </AuthLayout>
+  );
+}

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,139 +1,33 @@
 "use client"
-import { useState } from 'react';
-import { useTranslations } from 'next-intl';
+import { useEffect } from 'react';
 import { useRouter } from '@/i18n/routing';
-import AuthLayout from "@/components/AuthLayout";
-import InputField from "@/components/InputField";
-import SubmitButton from "@/components/SubmitButton";
+import { useAuth } from '@/context/AuthContext';
 
-export default function Login() {
-  const t = useTranslations('auth');
-  const router = useRouter();
+export default function RootPage() {
+    const { user, loading } = useAuth();
+    const router = useRouter();
 
-  const [formData, setFormData] = useState({
-    email: '',
-    password: ''
-  });
+    useEffect(() => {
+        // Solo actuamos cuando el AuthContext ha terminado de verificar la cookie
+        if (!loading) {
+            if (user) {
+                // Si hay usuario válido, al Dashboard
+                router.push('/dashboard');
+            } else {
+                // Si no hay token o es inválido, al Login
+                router.push('/login');
+            }
+        }
+    }, [user, loading, router]);
 
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  // --- ICONOS (Siguiendo tu formato dinámico) ---
-  const emailIcon = (color: string) => (
-    <path 
-      d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" 
-      stroke={color} 
-      strokeLinecap="round" 
-      strokeLinejoin="round" 
-    />
-  );
-
-  const lockIcon = (color: string) => (
-    <>
-      <rect x="3" y="11" width="18" height="11" rx="2" stroke={color} strokeLinecap="round" />
-      <path d="M7 11V7a5 5 0 0110 0v4" stroke={color} strokeLinecap="round" />
-    </>
-  );
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setFormData({ ...formData, [e.target.name]: e.target.value });
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-      e.preventDefault();
-      setLoading(true);
-      setError(null);
-
-      try {
-          // Para GET, pasamos los datos en la URL: ?email=...
-          const url = `http://127.0.0.1:8000/api/v1/users/?email=${formData.email}`;
-
-          const response = await fetch(url, {
-              method: 'GET', // <--- OBLIGATORIO: Debe ser GET
-              headers: {
-                  'Content-Type': 'application/json',
-              },
-              // ¡IMPORTANTE! No pongas body: JSON.stringify(...) aquí.
-          });
-
-          if (!response.ok) {
-              if (response.status === 405) {
-                  throw new Error("El servidor no acepta GET en esta ruta. Revisa el decorador en Python.");
-              }
-              throw new Error("Error al obtener datos");
-          }
-
-          const data = await response.json(); // Esto será el array que viste en Swagger
-          
-          // Como recibimos una lista, buscamos al usuario
-          const userFound = data.find((u: any) => u.email === formData.email);
-
-          if (userFound) {
-              router.push("/dashboard");
-          } else {
-              setError("Usuario no encontrado");
-          }
-
-      } catch (err: any) {
-          setError(err.message);
-      } finally {
-          setLoading(false);
-      }
-  };
-
-  return (
-    <AuthLayout>
-
-      <div className="h-px bg-blue-50 mb-8" />
-
-      {error && (
-        <div className="mb-6 p-4 text-sm text-red-600 bg-red-50 rounded-2xl border border-red-100 flex items-center gap-2 animate-shake">
-          <svg className="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-          </svg>
-          {error}
+    // Retornamos una pantalla en blanco o un cargando mientras se decide el destino
+    return (
+        <div className="h-screen w-screen flex items-center justify-center bg-white">
+            <div className="flex flex-col items-center gap-4">
+                {/* Spinner animado opcional */}
+                <div className="w-10 h-10 border-4 border-blue-600/20 border-t-blue-600 rounded-full animate-spin" />
+                <p className="text-gray-400 text-sm animate-pulse">Cargando ErasmusHub...</p>
+            </div>
         </div>
-      )}
-
-      <form className="space-y-5" onSubmit={handleSubmit} noValidate>
-        <InputField
-          label={t('emailLabel')}
-          type="email"
-          name="email"
-          value={formData.email}
-          onChange={handleChange}
-          placeholder={t('emailPlaceholder')}
-          icon={emailIcon}
-          required
-        />
-
-        <InputField
-          label={t('passwordLabel')}
-          type="password"
-          name="password"
-          value={formData.password}
-          onChange={handleChange}
-          placeholder={t('passwordPlaceholder')}
-          icon={lockIcon}
-          required
-        />
-
-        <div className="pt-2">
-          <SubmitButton disabled={loading}>
-            {loading ? "Entrando..." : t('signIn')}
-          </SubmitButton>
-        </div>
-      </form>
-
-      <p className="text-center text-gray-400 text-xs mt-8">
-        {t('dontHaveAccount')}{" "}
-        <span
-          onClick={() => router.push("/register")}
-          className="text-blue-600 font-bold hover:underline cursor-pointer transition-all"
-        >
-          {t('register')}
-        </span>
-      </p>
-    </AuthLayout>
-  );
+    );
 }

--- a/app/[locale]/register/page.tsx
+++ b/app/[locale]/register/page.tsx
@@ -77,7 +77,7 @@ export default function Register() {
         console.log("Cargando activado..."); // Añade este log para ver si llega aquí
 
         try {
-            const response = await fetch('http://127.0.0.1:8000/api/v1/users/', {
+            const response = await fetch('http://127.0.0.1:8000/users/', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({

--- a/components/UserDropdown.tsx
+++ b/components/UserDropdown.tsx
@@ -2,19 +2,21 @@
 import { useState, useRef, useEffect } from "react";
 import { useTranslations } from "next-intl";
 import { useRouter } from "@/i18n/routing";
+import { useAuth } from "@/context/AuthContext"; // 1. Importamos el hook de autenticación
 
 export default function UserDropdown() {
     const [isOpen, setIsOpen] = useState(false);
     const t = useTranslations("dashboard");
     const router = useRouter();
     const menuRef = useRef<HTMLDivElement>(null);
+    
+    // 2. Extraemos los datos del usuario real y la función logout del contexto
+    const { user, logout } = useAuth();
 
-    // Datos ficticios del usuario
-    const user = {
-        name: "Juan Sebastián",
-        email: "juan.erasmus@hub.com",
-        initials: "JS"
-    };
+    // 3. Generamos las iniciales dinámicamente basadas en el usuario real
+    const initials = user 
+        ? `${user.nombre.charAt(0)}${user.apellidos.charAt(0)}`.toUpperCase() 
+        : "??";
 
     useEffect(() => {
         const handleClickOutside = (event: MouseEvent) => {
@@ -24,9 +26,12 @@ export default function UserDropdown() {
         return () => document.removeEventListener("mousedown", handleClickOutside);
     }, []);
 
+    // Si por alguna razón no hay usuario, no mostramos el dropdown (o mostramos un estado de carga)
+    if (!user) return null;
+
     return (
         <div className="relative" ref={menuRef}>
-            {/* Trigger: Avatar pequeño en el Header */}
+            {/* Trigger: Avatar pequeño */}
             <button
                 onClick={() => setIsOpen(!isOpen)}
                 className="w-9 h-9 rounded-full flex items-center justify-center text-white text-xs font-bold shadow-sm transition-transform hover:scale-105 active:scale-95 border-2 border-white ring-1 ring-gray-100"
@@ -34,13 +39,13 @@ export default function UserDropdown() {
                     background: "linear-gradient(135deg, #3b82f6 0%, #1d4ed8 100%)",
                 }}
             >
-                {user.initials}
+                {initials}
             </button>
 
             {isOpen && (
                 <div className="absolute right-0 mt-3 w-64 bg-white rounded-2xl shadow-2xl border border-gray-100 overflow-hidden z-50 animate-in fade-in zoom-in duration-200">
 
-                    {/* Header del menú (Centrado) */}
+                    {/* Header del menú con datos REALES */}
                     <div className="flex flex-col items-center px-4 py-6 bg-gray-50/50 border-b border-gray-100">
                         <div
                             className="w-16 h-16 rounded-full flex items-center justify-center text-white text-xl font-bold mb-3 shadow-md border-4 border-white"
@@ -48,13 +53,14 @@ export default function UserDropdown() {
                                 background: "linear-gradient(135deg, #3b82f6 0%, #1d4ed8 100%)",
                             }}
                         >
-                            {user.initials}
+                            {initials}
                         </div>
-                        <p className="text-base font-bold text-gray-800 text-center">{user.name}</p>
+                        <p className="text-base font-bold text-gray-800 text-center">
+                            {user.nombre} {user.apellidos}
+                        </p>
                         <p className="text-xs text-gray-400 text-center">{user.email}</p>
                     </div>
 
-                    {/* Cuerpo del menú (Icono + Texto en línea) */}
                     <div className="p-2 space-y-1">
                         <button
                             onClick={() => { router.push('/dashboard/profile'); setIsOpen(false) }}
@@ -77,10 +83,10 @@ export default function UserDropdown() {
                         </button>
                     </div>
 
-                    {/* Footer: Cerrar sesión (Ligero fondo rojo) */}
+                    {/* Footer: Cerrar sesión (Usando la función del contexto) */}
                     <div className="p-2 border-t border-gray-50 bg-gray-50/30">
                         <button
-                            onClick={() => router.push('/')}
+                            onClick={() => logout()} // 4. Ejecutamos el logout real
                             className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-red-600 bg-red-50/50 hover:bg-red-50 rounded-xl transition-colors group"
                         >
                             <svg className="w-5 h-5 text-red-400 group-hover:text-red-600 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -1,0 +1,85 @@
+"use client"
+import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import Cookies from 'js-cookie';
+import { useRouter } from '@/i18n/routing';
+
+interface User {
+    id: number;
+    email: string;
+    nombre: string;
+    apellidos: string;
+}
+
+interface AuthContextType {
+    user: User | null;
+    loading: boolean;
+    loginGlobal: (token: string) => Promise<void>;
+    logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+    const [user, setUser] = useState<User | null>(null);
+    const [loading, setLoading] = useState(true);
+    const router = useRouter();
+
+    // Función para validar el token contra /auth/me
+    const checkUserSession = async () => {
+        const token = Cookies.get('auth_token');
+
+        if (!token) {
+            setUser(null);
+            setLoading(false);
+            return;
+        }
+
+        try {
+            const response = await fetch("http://127.0.0.1:8000/auth/me", {
+                method: 'GET',
+                headers: {
+                    'Authorization': `Bearer ${token}`, // Cabecera requerida por tu backend
+                    'Accept': 'application/json'
+                }
+            });
+
+            if (response.ok) {
+                const userData = await response.json();
+                setUser(userData);
+            } else {
+                // Si el backend da 401 (token expirado tras 30 min), borramos todo
+                logout();
+            }
+        } catch (error) {
+            console.error("Error de conexión:", error);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        checkUserSession();
+    }, []);
+
+    const loginGlobal = async (token: string) => {
+        await checkUserSession(); // Sincroniza el estado del usuario tras el login
+    };
+
+    const logout = () => {
+        Cookies.remove('auth_token');
+        setUser(null);
+        router.push('/login');
+    };
+
+    return (
+        <AuthContext.Provider value={{ user, loading, loginGlobal, logout }}>
+            {children}
+        </AuthContext.Provider>
+    );
+}
+
+export const useAuth = () => {
+    const context = useContext(AuthContext);
+    if (!context) throw new Error("useAuth debe usarse dentro de un AuthProvider");
+    return context;
+};

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -1,22 +1,31 @@
 {
   "auth": {
-    "login": "Přihlásit se",
-    "register": "Vytvořit účet",
-    "createAccountTitle": "Vytvořit účet",
-    "nameLabel": "Jméno",
-    "namePlaceholder": "Anna",
-    "lastNameLabel": "Příjmení",
-    "lastNamePlaceholder": "Nováková",
+    "welcomeTitle": "Vítejte zpět!",
+    "welcomeSubtitle": "Přihlaste se ke svému účtu a spravujte své záležitosti Erasmus",
     "emailLabel": "E-mailová adresa",
+    "emailPlaceholder": "priklad@mail.cz",
     "passwordLabel": "Heslo",
-    "emailPlaceholder": "tvuj@email.cz",
-    "passwordPlaceholder": "Minimálně 8 znaků",
+    "passwordPlaceholder": "••••••••",
+    "forgotPassword": "Zapomněli jste heslo?",
+    "signIn": "Přihlásit se",
+    "dontHaveAccount": "Nemáte účet?",
+    "register": "Zaregistrujte se zde",
+    "createAccountTitle": "Vytvořte si účet",
+    "nameLabel": "Jméno",
+    "namePlaceholder": "Vaše jméno",
+    "lastNameLabel": "Příjmení",
+    "lastNamePlaceholder": "Vaše příjmení",
     "confirmPasswordLabel": "Potvrdit heslo",
-    "confirmPasswordPlaceholder": "Zopakujte heslo",
-    "noAccount": "Nemáte účet?",
-    "registerFree": "Zaregistrujte se zdarma",
+    "confirmPasswordPlaceholder": "Zopakujte své heslo",
     "alreadyHaveAccount": "Již máte účet?",
-    "signIn": "Přihlaste se"
+    "loading": "Přihlašování...",
+    "errors": {
+      "emptyFields": "Prosím, vyplňte všechna pole.",
+      "invalidEmail": "E-mailová adresa není platná.",
+      "passwordTooShort": "Heslo musí mít alespoň 8 znaků.",
+      "badCredentials": "Nesprávný e-mail nebo heslo.",
+      "generic": "Něco se nepovedlo. Zkuste to prosím znovu."
+    }
   },
   
   "dashboard": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,22 +1,31 @@
 {
   "auth": {
-    "login": "Sign in",
-    "register": "Create account",
-    "createAccountTitle": "Create an account",
-    "nameLabel": "First Name",
-    "namePlaceholder": "Anna",
-    "lastNameLabel": "Last Name",
-    "lastNamePlaceholder": "Smith",
-    "emailLabel": "Email address",
+    "welcomeTitle": "Welcome back!",
+    "welcomeSubtitle": "Access your account to manage your Erasmus procedures",
+    "emailLabel": "Email Address",
+    "emailPlaceholder": "example@mail.com",
     "passwordLabel": "Password",
-    "emailPlaceholder": "you@email.com",
-    "passwordPlaceholder": "Minimum 8 characters",
-    "confirmPasswordLabel": "Confirm password",
+    "passwordPlaceholder": "••••••••",
+    "forgotPassword": "Forgot your password?",
+    "signIn": "Sign In",
+    "dontHaveAccount": "Don't have an account?",
+    "register": "Register here",
+    "createAccountTitle": "Create your account",
+    "nameLabel": "First Name",
+    "namePlaceholder": "Your name",
+    "lastNameLabel": "Last Name",
+    "lastNamePlaceholder": "Your last name",
+    "confirmPasswordLabel": "Confirm Password",
     "confirmPasswordPlaceholder": "Repeat your password",
-    "noAccount": "Don't have an account?",
-    "registerFree": "Sign up for free",
     "alreadyHaveAccount": "Already have an account?",
-    "signIn": "Sign in"
+    "loading": "Signing in...",
+    "errors": {
+      "emptyFields": "Please fill in all fields.",
+      "invalidEmail": "The email address is not valid.",
+      "passwordTooShort": "Password must be at least 8 characters long.",
+      "badCredentials": "Invalid email or password.",
+      "generic": "Something went wrong. Please try again."
+    }
   },
 
   "dashboard": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -17,9 +17,16 @@
     "lastNamePlaceholder": "Tus apellidos",
     "confirmPasswordLabel": "Confirmar Contraseña",
     "confirmPasswordPlaceholder": "Repite tu contraseña",
-    "alreadyHaveAccount": "¿Ya tienes una cuenta?"
-  }
-}
+    "alreadyHaveAccount": "¿Ya tienes una cuenta?",
+    "loading": "Entrando...",
+    "errors": {
+      "emptyFields": "Por favor, rellena todos los campos.",
+      "invalidEmail": "El correo electrónico no es válido.",
+      "passwordTooShort": "La contraseña debe tener al menos 8 caracteres.",
+      "badCredentials": "Email o contraseña incorrectos.",
+      "generic": "Algo salió mal. Inténtalo de nuevo."
+    }
+  },
 
   "dashboard": {
     "home": "Inicio",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "erasmus-hub",
       "version": "0.1.0",
       "dependencies": {
+        "js-cookie": "^3.0.5",
         "next": "16.1.6",
         "next-intl": "^4.8.3",
         "react": "19.2.3",
@@ -15,6 +16,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@types/js-cookie": "^3.0.6",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -2069,6 +2071,13 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/js-cookie": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
+      "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5003,6 +5012,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "js-cookie": "^3.0.5",
     "next": "16.1.6",
     "next-intl": "^4.8.3",
     "react": "19.2.3",
@@ -16,6 +17,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@types/js-cookie": "^3.0.6",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",


### PR DESCRIPTION
Introduce a client-side AuthContext and integrate session handling across the app. Added context/AuthContext.tsx (useAuth, AuthProvider) and wired it into app/[locale]/layout.tsx so the whole app has access to auth state. Implemented a proper login page at app/[locale]/login/page.tsx that stores auth_token in cookies and calls loginGlobal. Protect dashboard with server-side cookie/token validation and redirects in app/[locale]/dashboard/layout.tsx. Replace the root page with a small router that forwards users to /dashboard or /login based on auth state (app/[locale]/page.tsx). Updated UserDropdown to consume useAuth (show real user info and call logout). Fixed registration fetch endpoint and added i18n messages updates (cs, en, es) for auth UI and errors. Added js-cookie and its types to package.json and package-lock.json to manage cookies. These changes centralize authentication, perform token validation, and provide a smoother login/logout flow.

## ✨ Descripción
(Describe brevemente qué añade o corrige este Pull Request.)

## 🔗 Issue relacionado
Fixes #1 Tokens
<!-- Ejemplo: Fixes #21 -->

---