### PR TITLE
Add role translations and theme integration

### DIFF
--- a/app/[locale]/(dashboard)/dashboard/page.tsx
+++ b/app/[locale]/(dashboard)/dashboard/page.tsx
@@ -102,13 +102,28 @@ export default function DashboardHome() {
     return (
         <div className="space-y-6">
             {/* Welcome header */}
-            <div className={`bg-gradient-to-r ${theme.gradientFrom} ${theme.gradientTo} rounded-2xl p-8 text-white`}>
-                <h1 className="text-2xl font-bold mb-1">
-                    {t("welcomeBack", { greeting, name: user?.first_name || "" })}
-                </h1>
-                <p className={`${theme.gradientSubtext} text-sm`}>
-                    {t("welcomeSubtitle")}
-                </p>
+            <div className="relative bg-white rounded-3xl border border-gray-100 shadow-sm overflow-hidden">
+                {/* Accent bar */}
+                <div className={`absolute inset-y-0 left-0 w-1.5 bg-gradient-to-b ${theme.gradientFrom} ${theme.gradientTo}`} />
+                <div className="flex items-center gap-5 px-8 py-7">
+                    {/* Avatar */}
+                    <div
+                        className="hidden sm:flex w-14 h-14 rounded-2xl items-center justify-center text-white text-lg font-bold shrink-0 shadow-sm"
+                        style={{ background: `linear-gradient(135deg, var(--tw-gradient-from, #7c3aed), var(--tw-gradient-to, #6d28d9))` }}
+                    >
+                        <span className={`w-14 h-14 rounded-2xl flex items-center justify-center bg-gradient-to-br ${theme.gradientFrom} ${theme.gradientTo}`}>
+                            {user?.first_name?.charAt(0)}{user?.last_name?.charAt(0)}
+                        </span>
+                    </div>
+                    <div className="min-w-0">
+                        <h1 className="text-xl sm:text-2xl font-bold text-gray-800 truncate">
+                            {t("welcomeBack", { greeting, name: user?.first_name || "" })}
+                        </h1>
+                        <p className="text-sm text-gray-400 mt-0.5">
+                            {t("welcomeSubtitle")}
+                        </p>
+                    </div>
+                </div>
             </div>
 
             {/* Stats cards - only for students */}

--- a/app/[locale]/(dashboard)/dashboard/profile/page.tsx
+++ b/app/[locale]/(dashboard)/dashboard/profile/page.tsx
@@ -3,10 +3,12 @@
 import { useTranslations } from "next-intl";
 import { useAuth } from "@/context/AuthContext";
 import { useRoleTheme } from "@/hooks/useRoleTheme";
+import { translateRole } from "@/lib/translateRole";
 import LoadingSpinner from "@/components/ui/LoadingSpinner";
 
 export default function UserProfilePage() {
     const t = useTranslations("userProfile");
+    const tRoles = useTranslations("roles");
     const { user, loading } = useAuth();
     const theme = useRoleTheme();
 
@@ -55,7 +57,7 @@ export default function UserProfilePage() {
                         <span
                             className={`px-3 py-1.5 rounded-full text-sm font-semibold ${theme.pillBg} ${theme.pillText}`}
                         >
-                            {user.role?.name || t("notProvided")}
+                            {user.role?.name ? translateRole(user.role.name, tRoles) : t("notProvided")}
                         </span>
                     </div>
                 </div>
@@ -114,7 +116,7 @@ export default function UserProfilePage() {
                     <h2 className="text-lg font-bold text-gray-800">{t("accountInfo")}</h2>
                 </div>
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                    <InfoRow label={t("role")} value={user.role?.name} badge={
+                    <InfoRow label={t("role")} value={user.role?.name ? translateRole(user.role.name, tRoles) : undefined} badge={
                         user.role?.name?.toLowerCase().includes("admin") ? "purple" : "green"
                     } />
                     <InfoRow label={t("memberSince")} value={formatDate(user.created_at)} />

--- a/app/[locale]/(dashboard)/dashboard/unauthorized/page.tsx
+++ b/app/[locale]/(dashboard)/dashboard/unauthorized/page.tsx
@@ -1,20 +1,17 @@
-import Link from 'next/link';
+'use client';
+
+import { useTranslations } from 'next-intl';
+import AccessDenied from '@/components/ui/AccessDenied';
 
 export default function UnauthorizedPage() {
-  return (
-    <div className="min-h-[calc(100vh-3rem)] flex flex-col items-center justify-center bg-gray-50 p-6">
-      <div className="max-w-md w-full bg-white p-10 rounded-3xl shadow-sm border border-gray-100 text-center">
-        <h1 className="text-3xl font-bold text-gray-800 mb-4">Access denied</h1>
-        <p className="text-gray-600 mb-6">
-          You do not have permission to view this page. If you believe this is an error, please contact your administrator.
-        </p>
-        <Link
-          href="/dashboard"
-          className="inline-flex items-center justify-center px-6 py-2 rounded-full bg-blue-600 text-white font-semibold hover:bg-blue-700 transition"
-        >
-          Go back to dashboard
-        </Link>
-      </div>
-    </div>
-  );
+    const t = useTranslations('accessDenied');
+
+    return (
+        <AccessDenied
+            title={t('title')}
+            message={t('message')}
+            backLabel={t('backLabel')}
+            backHref="/dashboard"
+        />
+    );
 }

--- a/components/admin/UserTable.tsx
+++ b/components/admin/UserTable.tsx
@@ -6,6 +6,8 @@ import Cookies from 'js-cookie';
 import { API_URL } from '@/lib/api';
 import FilterBar from '@/components/ui/FilterBar';
 import Pagination from '@/components/ui/Pagination';
+import { useRoleTheme } from '@/hooks/useRoleTheme';
+import { translateRole } from '@/lib/translateRole';
 import type { User, Role } from '@/services/userService';
 
 const PAGE_SIZE = 10;
@@ -72,11 +74,12 @@ function Modal({ open, onClose, children }: { open: boolean; onClose: () => void
 /* ── Action buttons ─────────────────────────────────────────── */
 
 function ActionButtons({ onEdit, onDelete }: { onEdit: () => void; onDelete: () => void }) {
+    const theme = useRoleTheme();
     return (
         <div className="flex items-center gap-1">
             <button
                 onClick={onEdit}
-                className="p-1.5 rounded-lg text-gray-400 hover:text-purple-600 hover:bg-purple-50 transition-colors cursor-pointer"
+                className={`p-1.5 rounded-lg text-gray-400 ${theme.hoverText} ${theme.hoverBg} transition-colors cursor-pointer`}
             >
                 <PencilIcon />
             </button>
@@ -102,6 +105,8 @@ function PlusIcon() {
 
 function CreateUserModal({ roles, open, onClose, onCreated }: { roles: Role[]; open: boolean; onClose: () => void; onCreated: () => void }) {
     const t = useTranslations('adminDashboard');
+    const tRoles = useTranslations('roles');
+    const theme = useRoleTheme();
     const [form, setForm] = useState({
         first_name: '', last_name: '', email: '', phone: '', role_id: '',
     });
@@ -161,35 +166,35 @@ function CreateUserModal({ roles, open, onClose, onCreated }: { roles: Role[]; o
                     <div>
                         <label className="block text-xs font-medium text-gray-500 mb-1">{t('firstName')}</label>
                         <input type="text" value={form.first_name} onChange={e => updateField('first_name', e.target.value)}
-                            className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-200 focus:border-purple-400 transition-colors" />
+                            className={`w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`} />
                     </div>
                     <div>
                         <label className="block text-xs font-medium text-gray-500 mb-1">{t('lastName')}</label>
                         <input type="text" value={form.last_name} onChange={e => updateField('last_name', e.target.value)}
-                            className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-200 focus:border-purple-400 transition-colors" />
+                            className={`w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`} />
                     </div>
                 </div>
                 <div>
                     <label className="block text-xs font-medium text-gray-500 mb-1">{t('fieldEmail')}</label>
                     <input type="email" value={form.email} onChange={e => updateField('email', e.target.value)}
                         placeholder={t('fieldEmailPlaceholder')}
-                        className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-200 focus:border-purple-400 transition-colors" />
+                        className={`w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`} />
                 </div>
                 <div className="grid grid-cols-2 gap-3">
                     <div>
                         <label className="block text-xs font-medium text-gray-500 mb-1">{t('fieldPhone')}</label>
                         <input type="tel" value={form.phone} onChange={e => updateField('phone', e.target.value)}
                             placeholder={t('fieldPhonePlaceholder')}
-                            className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-200 focus:border-purple-400 transition-colors" />
+                            className={`w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`} />
                     </div>
                     <div>
                         <label className="block text-xs font-medium text-gray-500 mb-1">{t('fieldRole')}</label>
                         <div className="relative">
                             <select value={form.role_id} onChange={e => updateField('role_id', e.target.value)}
-                                className="w-full appearance-none rounded-xl border border-gray-200 bg-white px-3 py-2 pr-8 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-200 focus:border-purple-400 transition-colors cursor-pointer">
+                                className={`w-full appearance-none rounded-xl border border-gray-200 bg-white px-3 py-2 pr-8 text-sm text-gray-700 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors cursor-pointer`}>
                                 <option value="">{t('selectRolePlaceholder')}</option>
                                 {roles.map((role) => (
-                                    <option key={role.id} value={role.id.toString()}>{role.name}</option>
+                                    <option key={role.id} value={role.id.toString()}>{translateRole(role.name, tRoles)}</option>
                                 ))}
                             </select>
                             <div className="absolute inset-y-0 right-2 flex items-center text-gray-400 pointer-events-none">
@@ -212,7 +217,7 @@ function CreateUserModal({ roles, open, onClose, onCreated }: { roles: Role[]; o
                     {t('cancel')}
                 </button>
                 <button onClick={handleCreate} disabled={!form.first_name.trim() || !form.email.trim() || creating}
-                    className={`px-4 py-2 rounded-xl text-sm font-medium text-white transition-colors ${!form.first_name.trim() || !form.email.trim() || creating ? 'bg-purple-400 cursor-not-allowed opacity-60' : 'bg-purple-600 hover:bg-purple-700 cursor-pointer'}`}>
+                    className={`px-4 py-2 rounded-xl text-sm font-medium text-white transition-colors ${!form.first_name.trim() || !form.email.trim() || creating ? `${theme.btnDisabled} cursor-not-allowed opacity-60` : `${theme.btnPrimary} ${theme.btnPrimaryHover} cursor-pointer`}`}>
                     {creating ? t('creating') : t('save')}
                 </button>
             </div>
@@ -224,6 +229,8 @@ function CreateUserModal({ roles, open, onClose, onCreated }: { roles: Role[]; o
 
 function EditModal({ user, roles, open, onClose }: { user: User | null; roles: Role[]; open: boolean; onClose: () => void }) {
     const t = useTranslations('adminDashboard');
+    const tRoles = useTranslations('roles');
+    const theme = useRoleTheme();
     if (!user) return null;
 
     return (
@@ -243,7 +250,7 @@ function EditModal({ user, roles, open, onClose }: { user: User | null; roles: R
                         <input
                             type="text"
                             defaultValue={user.first_name}
-                            className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-200 focus:border-purple-400 transition-colors"
+                            className={`w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`}
                         />
                     </div>
                     <div>
@@ -251,7 +258,7 @@ function EditModal({ user, roles, open, onClose }: { user: User | null; roles: R
                         <input
                             type="text"
                             defaultValue={user.last_name}
-                            className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-200 focus:border-purple-400 transition-colors"
+                            className={`w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`}
                         />
                     </div>
                 </div>
@@ -260,7 +267,7 @@ function EditModal({ user, roles, open, onClose }: { user: User | null; roles: R
                     <input
                         type="email"
                         defaultValue={user.email}
-                        className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-200 focus:border-purple-400 transition-colors"
+                        className={`w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`}
                     />
                 </div>
                 <div className="grid grid-cols-2 gap-3">
@@ -269,7 +276,7 @@ function EditModal({ user, roles, open, onClose }: { user: User | null; roles: R
                         <input
                             type="tel"
                             defaultValue={user.phone}
-                            className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-200 focus:border-purple-400 transition-colors"
+                            className={`w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`}
                         />
                     </div>
                     <div>
@@ -277,11 +284,11 @@ function EditModal({ user, roles, open, onClose }: { user: User | null; roles: R
                         <div className="relative">
                             <select
                                 defaultValue={user.role?.id?.toString() ?? ''}
-                                className="w-full appearance-none rounded-xl border border-gray-200 bg-white px-3 py-2 pr-8 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-200 focus:border-purple-400 transition-colors cursor-pointer"
+                                className={`w-full appearance-none rounded-xl border border-gray-200 bg-white px-3 py-2 pr-8 text-sm text-gray-700 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors cursor-pointer`}
                             >
                                 {roles.map((role) => (
                                     <option key={role.id} value={role.id.toString()}>
-                                        {role.name}
+                                        {translateRole(role.name, tRoles)}
                                     </option>
                                 ))}
                             </select>
@@ -296,7 +303,7 @@ function EditModal({ user, roles, open, onClose }: { user: User | null; roles: R
                     <input
                         type="text"
                         defaultValue={user.address}
-                        className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-200 focus:border-purple-400 transition-colors"
+                        className={`w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`}
                     />
                 </div>
             </div>
@@ -310,7 +317,7 @@ function EditModal({ user, roles, open, onClose }: { user: User | null; roles: R
                 </button>
                 <button
                     onClick={onClose}
-                    className="px-4 py-2 rounded-xl text-sm font-medium text-white bg-purple-600 hover:bg-purple-700 transition-colors cursor-pointer"
+                    className={`px-4 py-2 rounded-xl text-sm font-medium text-white ${theme.btnPrimary} ${theme.btnPrimaryHover} transition-colors cursor-pointer`}
                 >
                     {t('save')}
                 </button>
@@ -367,6 +374,7 @@ function DeleteModal({ user, open, onClose }: { user: User | null; open: boolean
 
 export default function UserTable({ users }: { users: User[] }) {
     const t = useTranslations('adminDashboard');
+    const tRoles = useTranslations('roles');
     const [searchQuery, setSearchQuery] = useState('');
     const [editUser, setEditUser] = useState<User | null>(null);
     const [deleteUser, setDeleteUser] = useState<User | null>(null);
@@ -429,7 +437,7 @@ export default function UserTable({ users }: { users: User[] }) {
                         ),
                         value: roleFilter,
                         onChange: setRoleFilter,
-                        options: roles.map(r => ({ value: r.id.toString(), label: r.name })),
+                        options: roles.map(r => ({ value: r.id.toString(), label: translateRole(r.name, tRoles) })),
                     },
                     {
                         type: 'checkbox',
@@ -477,8 +485,9 @@ export default function UserTable({ users }: { users: User[] }) {
                             </thead>
                             <tbody className="divide-y divide-gray-50">
                                 {paginatedUsers.map((user) => {
-                                    const roleName = user.role?.name ?? t('unknown');
-                                    const pillClasses = getRolePillClasses(roleName);
+                                    const rawRole = user.role?.name ?? '';
+                                    const displayRole = rawRole ? translateRole(rawRole, tRoles) : t('unknown');
+                                    const pillClasses = getRolePillClasses(rawRole);
 
                                     return (
                                         <tr key={user.id} className="group hover:bg-gray-50/80 transition-colors">
@@ -489,7 +498,7 @@ export default function UserTable({ users }: { users: User[] }) {
                                             <td className="py-4 text-gray-500">{user.phone || '—'}</td>
                                             <td className="py-4">
                                                 <span className={`px-2 py-1 rounded-lg text-xs font-semibold ${pillClasses}`}>
-                                                    {roleName}
+                                                    {displayRole}
                                                 </span>
                                             </td>
                                             <td className="py-4 text-gray-500 text-sm">
@@ -523,8 +532,9 @@ export default function UserTable({ users }: { users: User[] }) {
                     {/* Mobile cards */}
                     <div className="lg:hidden space-y-3">
                         {paginatedUsers.map((user) => {
-                            const roleName = user.role?.name ?? t('unknown');
-                            const pillClasses = getRolePillClasses(roleName);
+                            const rawRole = user.role?.name ?? '';
+                            const displayRole = rawRole ? translateRole(rawRole, tRoles) : t('unknown');
+                            const pillClasses = getRolePillClasses(rawRole);
 
                             return (
                                 <div key={user.id} className="rounded-2xl border border-gray-100 p-4 space-y-3">
@@ -539,7 +549,7 @@ export default function UserTable({ users }: { users: User[] }) {
                                                 </span>
                                             )}
                                             <span className={`px-2 py-0.5 rounded-lg text-xs font-semibold ${pillClasses}`}>
-                                                {roleName}
+                                                {displayRole}
                                             </span>
                                         </div>
                                     </div>

--- a/components/dropdowns/UserMenuDropdown.tsx
+++ b/components/dropdowns/UserMenuDropdown.tsx
@@ -4,10 +4,12 @@ import { useTranslations } from "next-intl";
 import { useRouter } from "@/i18n/routing";
 import { useAuth } from "@/context/AuthContext";
 import { useRoleTheme } from "@/hooks/useRoleTheme";
+import { translateRole } from "@/lib/translateRole";
 
 export default function UserMenuDropdown() {
     const [isOpen, setIsOpen] = useState(false);
     const t = useTranslations("dashboard");
+    const tRoles = useTranslations("roles");
     const router = useRouter();
     const menuRef = useRef<HTMLDivElement>(null);
 
@@ -63,7 +65,7 @@ export default function UserMenuDropdown() {
                         </p>
                         <p className="text-xs text-gray-400 text-center">{user?.email}</p>
                         <p className="text-xs text-gray-500 mt-1">
-                            {user?.role?.name || 'Sin rol'}
+                            {translateRole(user?.role?.name, tRoles)}
                         </p>
                     </div>
 

--- a/components/form/FormSubmitButton.tsx
+++ b/components/form/FormSubmitButton.tsx
@@ -1,5 +1,6 @@
 "use client"
 import React from "react";
+import { useTranslations } from "next-intl";
 
 // Allows the component to accept all standard HTML button properties
 interface SubmitButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -8,6 +9,7 @@ interface SubmitButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement
 }
 
 export default function FormSubmitButton({ children, disabled, className, ...props }: SubmitButtonProps) {
+    const t = useTranslations("common");
     return (
         <button
             {...props} // Passes onClick, onBlur, etc. automatically
@@ -32,7 +34,7 @@ export default function FormSubmitButton({ children, disabled, className, ...pro
                         <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
                         <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                     </svg>
-                    <span>Loading...</span>
+                    <span>{t("loading")}</span>
                 </div>
             ) : (
                 children

--- a/components/opportunities/OpportunityTable.tsx
+++ b/components/opportunities/OpportunityTable.tsx
@@ -7,6 +7,7 @@ import { API_URL } from '@/lib/api';
 import { getCountryFlagUrl } from '@/lib/countryFlags';
 import FilterBar from '@/components/ui/FilterBar';
 import Pagination from '@/components/ui/Pagination';
+import { useRoleTheme } from '@/hooks/useRoleTheme';
 import Cookies from 'js-cookie';
 import type { Opportunity } from '@/services/opportunityService';
 
@@ -81,7 +82,7 @@ function SlotsBar({ filled, max }: { filled: number; max: number }) {
 
 /* ── Student pills for assigned students ───────────────────── */
 
-function StudentPills({ students, t }: { students: AssignedStudent[]; t: (key: string) => string }) {
+function StudentPills({ students, t, theme }: { students: AssignedStudent[]; t: (key: string) => string; theme: ReturnType<typeof useRoleTheme> }) {
     if (students.length === 0) {
         return <span className="text-xs text-gray-400 italic">{t('noStudentsAssigned')}</span>;
     }
@@ -90,7 +91,7 @@ function StudentPills({ students, t }: { students: AssignedStudent[]; t: (key: s
             {students.map((s) => (
                 <span
                     key={s.application_id}
-                    className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-blue-50 text-blue-700"
+                    className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${theme.accentBg} ${theme.accentText}`}
                     title={s.email}
                 >
                     {s.first_name} {s.last_name}
@@ -105,6 +106,7 @@ function StudentPills({ students, t }: { students: AssignedStudent[]; t: (key: s
 
 function CreateModal({ open, onClose, onCreated }: { open: boolean; onClose: () => void; onCreated: () => void }) {
     const t = useTranslations('opportunitiesDashboard');
+    const theme = useRoleTheme();
     const [form, setForm] = useState({
         name: '', description: '', country: '', city: '',
         max_slots: '1', start_date: '', end_date: '',
@@ -170,43 +172,43 @@ function CreateModal({ open, onClose, onCreated }: { open: boolean; onClose: () 
                         <label className="block text-xs font-medium text-gray-500 mb-1">{t('fieldName')}</label>
                         <input type="text" value={form.name} onChange={e => updateField('name', e.target.value)}
                             placeholder={t('fieldNamePlaceholder')}
-                            className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-200 focus:border-blue-400 transition-colors" />
+                            className={`w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`} />
                     </div>
                     <div>
                         <label className="block text-xs font-medium text-gray-500 mb-1">{t('fieldDescription')}</label>
                         <textarea value={form.description} onChange={e => updateField('description', e.target.value)}
                             placeholder={t('fieldDescriptionPlaceholder')} rows={2}
-                            className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-200 focus:border-blue-400 transition-colors resize-none" />
+                            className={`w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors resize-none`} />
                     </div>
                     <div className="grid grid-cols-2 gap-3">
                         <div>
                             <label className="block text-xs font-medium text-gray-500 mb-1">{t('fieldCountry')}</label>
                             <input type="text" value={form.country} onChange={e => updateField('country', e.target.value)}
                                 placeholder={t('fieldCountryPlaceholder')}
-                                className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-200 focus:border-blue-400 transition-colors" />
+                                className={`w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`} />
                         </div>
                         <div>
                             <label className="block text-xs font-medium text-gray-500 mb-1">{t('fieldCity')}</label>
                             <input type="text" value={form.city} onChange={e => updateField('city', e.target.value)}
                                 placeholder={t('fieldCityPlaceholder')}
-                                className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-200 focus:border-blue-400 transition-colors" />
+                                className={`w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`} />
                         </div>
                     </div>
                     <div className="grid grid-cols-3 gap-3">
                         <div>
                             <label className="block text-xs font-medium text-gray-500 mb-1">{t('fieldMaxSlots')}</label>
                             <input type="number" min="1" value={form.max_slots} onChange={e => updateField('max_slots', e.target.value)}
-                                className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-200 focus:border-blue-400 transition-colors" />
+                                className={`w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`} />
                         </div>
                         <div>
                             <label className="block text-xs font-medium text-gray-500 mb-1">{t('fieldStartDate')}</label>
                             <input type="date" value={form.start_date} onChange={e => updateField('start_date', e.target.value)}
-                                className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-200 focus:border-blue-400 transition-colors" />
+                                className={`w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`} />
                         </div>
                         <div>
                             <label className="block text-xs font-medium text-gray-500 mb-1">{t('fieldEndDate')}</label>
                             <input type="date" value={form.end_date} onChange={e => updateField('end_date', e.target.value)}
-                                className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-200 focus:border-blue-400 transition-colors" />
+                                className={`w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`} />
                         </div>
                     </div>
                 </div>
@@ -223,7 +225,7 @@ function CreateModal({ open, onClose, onCreated }: { open: boolean; onClose: () 
                         {t('cancel')}
                     </button>
                     <button onClick={handleCreate} disabled={!form.name.trim() || creating}
-                        className={`px-4 py-2 rounded-xl text-sm font-medium text-white transition-colors ${!form.name.trim() || creating ? 'bg-blue-400 cursor-not-allowed opacity-60' : 'bg-blue-600 hover:bg-blue-700 cursor-pointer'}`}>
+                        className={`px-4 py-2 rounded-xl text-sm font-medium text-white transition-colors ${!form.name.trim() || creating ? `${theme.btnDisabled} cursor-not-allowed opacity-60` : `${theme.btnPrimary} ${theme.btnPrimaryHover} cursor-pointer`}`}>
                         {creating ? t('creating') : t('create')}
                     </button>
                 </div>
@@ -236,6 +238,7 @@ function CreateModal({ open, onClose, onCreated }: { open: boolean; onClose: () 
 
 function EditModal({ opp, open, onClose, onUpdated }: { opp: OpportunityWithStudents | null; open: boolean; onClose: () => void; onUpdated: () => void }) {
     const t = useTranslations('opportunitiesDashboard');
+    const theme = useRoleTheme();
     const [form, setForm] = useState({
         name: '', description: '', country: '', city: '',
         max_slots: '1', status: 'open', start_date: '', end_date: '',
@@ -318,39 +321,39 @@ function EditModal({ opp, open, onClose, onUpdated }: { opp: OpportunityWithStud
                         <label className="block text-xs font-medium text-gray-500 mb-1">{t('fieldName')}</label>
                         <input type="text" value={form.name} onChange={e => updateField('name', e.target.value)}
                             placeholder={t('fieldNamePlaceholder')}
-                            className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-200 focus:border-blue-400 transition-colors" />
+                            className={`w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`} />
                     </div>
                     <div>
                         <label className="block text-xs font-medium text-gray-500 mb-1">{t('fieldDescription')}</label>
                         <textarea value={form.description} onChange={e => updateField('description', e.target.value)}
                             placeholder={t('fieldDescriptionPlaceholder')} rows={2}
-                            className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-200 focus:border-blue-400 transition-colors resize-none" />
+                            className={`w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors resize-none`} />
                     </div>
                     <div className="grid grid-cols-2 gap-3">
                         <div>
                             <label className="block text-xs font-medium text-gray-500 mb-1">{t('fieldCountry')}</label>
                             <input type="text" value={form.country} onChange={e => updateField('country', e.target.value)}
                                 placeholder={t('fieldCountryPlaceholder')}
-                                className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-200 focus:border-blue-400 transition-colors" />
+                                className={`w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`} />
                         </div>
                         <div>
                             <label className="block text-xs font-medium text-gray-500 mb-1">{t('fieldCity')}</label>
                             <input type="text" value={form.city} onChange={e => updateField('city', e.target.value)}
                                 placeholder={t('fieldCityPlaceholder')}
-                                className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-200 focus:border-blue-400 transition-colors" />
+                                className={`w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`} />
                         </div>
                     </div>
                     <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
                         <div>
                             <label className="block text-xs font-medium text-gray-500 mb-1">{t('fieldMaxSlots')}</label>
                             <input type="number" min="1" value={form.max_slots} onChange={e => updateField('max_slots', e.target.value)}
-                                className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-200 focus:border-blue-400 transition-colors" />
+                                className={`w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`} />
                         </div>
                         <div>
                             <label className="block text-xs font-medium text-gray-500 mb-1">{t('status')}</label>
                             <div className="relative">
                                 <select value={form.status} onChange={e => updateField('status', e.target.value)}
-                                    className="w-full appearance-none rounded-xl border border-gray-200 bg-white px-3 py-2 pr-8 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-200 focus:border-blue-400 transition-colors cursor-pointer">
+                                    className={`w-full appearance-none rounded-xl border border-gray-200 bg-white px-3 py-2 pr-8 text-sm text-gray-700 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors cursor-pointer`}>
                                     <option value="open">{t('open')}</option>
                                     <option value="closed">{t('closed')}</option>
                                 </select>
@@ -362,12 +365,12 @@ function EditModal({ opp, open, onClose, onUpdated }: { opp: OpportunityWithStud
                         <div>
                             <label className="block text-xs font-medium text-gray-500 mb-1">{t('fieldStartDate')}</label>
                             <input type="date" value={form.start_date} onChange={e => updateField('start_date', e.target.value)}
-                                className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-200 focus:border-blue-400 transition-colors" />
+                                className={`w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`} />
                         </div>
                         <div>
                             <label className="block text-xs font-medium text-gray-500 mb-1">{t('fieldEndDate')}</label>
                             <input type="date" value={form.end_date} onChange={e => updateField('end_date', e.target.value)}
-                                className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-200 focus:border-blue-400 transition-colors" />
+                                className={`w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`} />
                         </div>
                     </div>
                 </div>
@@ -384,7 +387,7 @@ function EditModal({ opp, open, onClose, onUpdated }: { opp: OpportunityWithStud
                         {t('cancel')}
                     </button>
                     <button onClick={handleSave} disabled={!form.name.trim() || saving}
-                        className={`px-4 py-2 rounded-xl text-sm font-medium text-white transition-colors ${!form.name.trim() || saving ? 'bg-blue-400 cursor-not-allowed opacity-60' : 'bg-blue-600 hover:bg-blue-700 cursor-pointer'}`}>
+                        className={`px-4 py-2 rounded-xl text-sm font-medium text-white transition-colors ${!form.name.trim() || saving ? `${theme.btnDisabled} cursor-not-allowed opacity-60` : `${theme.btnPrimary} ${theme.btnPrimaryHover} cursor-pointer`}`}>
                         {saving ? t('saving') : t('save')}
                     </button>
                 </div>
@@ -398,6 +401,7 @@ function EditModal({ opp, open, onClose, onUpdated }: { opp: OpportunityWithStud
 export default function OpportunityTable({ opportunities }: { opportunities: OpportunityWithStudents[] }) {
     const t = useTranslations('opportunitiesDashboard');
     const { user } = useAuth();
+    const theme = useRoleTheme();
     const [searchQuery, setSearchQuery] = useState('');
     const [statusFilter, setStatusFilter] = useState('');
     const [countryFilter, setCountryFilter] = useState<string[]>([]);
@@ -467,7 +471,7 @@ export default function OpportunityTable({ opportunities }: { opportunities: Opp
                         type: 'pills',
                         key: 'country',
                         label: t('country'),
-                        iconColor: 'text-blue-500',
+                        iconColor: theme.accent,
                         icon: (
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
                                 <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-1.5 0a6.5 6.5 0 11-11-4.69v.001a6.489 6.489 0 003.995 2.127.75.75 0 01.654.741v.674c0 .37.27.688.636.74a6.547 6.547 0 001.43 0 .751.751 0 01.636-.74v-.674a.75.75 0 01.654-.741A6.489 6.489 0 0016.5 5.312 6.5 6.5 0 0116.5 10z" clipRule="evenodd" />
@@ -535,13 +539,13 @@ export default function OpportunityTable({ opportunities }: { opportunities: Opp
                                         <td className="py-4 pr-6 text-gray-500 text-sm">
                                             {opp.start_date ? new Date(opp.start_date).toLocaleDateString() : '—'}
                                         </td>
-                                        <td className="py-4"><StudentPills students={opp.students} t={t} /></td>
+                                        <td className="py-4"><StudentPills students={opp.students} t={t} theme={theme} /></td>
                                         {canManage && (
                                             <td className="py-4">
                                                 <div className="opacity-0 group-hover:opacity-100 transition-opacity">
                                                     <button
                                                         onClick={() => setEditOpp(opp)}
-                                                        className="p-1.5 rounded-lg text-gray-400 hover:text-blue-600 hover:bg-blue-50 transition-colors cursor-pointer"
+                                                        className={`p-1.5 rounded-lg text-gray-400 ${theme.hoverText} ${theme.hoverBg} transition-colors cursor-pointer`}
                                                         title={t('editTitle')}
                                                     >
                                                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
@@ -588,13 +592,13 @@ export default function OpportunityTable({ opportunities }: { opportunities: Opp
                                 </div>
                                 <div>
                                     <p className="text-xs text-gray-400 mb-1">{t('assignedStudents')}:</p>
-                                    <StudentPills students={opp.students} t={t} />
+                                    <StudentPills students={opp.students} t={t} theme={theme} />
                                 </div>
                                 {canManage && (
                                     <div className="flex justify-end border-t border-gray-50 pt-2">
                                         <button
                                             onClick={() => setEditOpp(opp)}
-                                            className="px-3 py-1.5 rounded-lg text-xs font-semibold text-blue-700 bg-blue-50 hover:bg-blue-100 transition-colors cursor-pointer"
+                                            className={`px-3 py-1.5 rounded-lg text-xs font-semibold ${theme.accentText} ${theme.accentBg} ${theme.softHover} transition-colors cursor-pointer`}
                                         >
                                             {t('editTitle')}
                                         </button>

--- a/components/students/StudentTable.tsx
+++ b/components/students/StudentTable.tsx
@@ -6,6 +6,8 @@ import Cookies from 'js-cookie';
 import { API_URL } from '@/lib/api';
 import FilterBar from '@/components/ui/FilterBar';
 import Pagination from '@/components/ui/Pagination';
+import { useRoleTheme } from '@/hooks/useRoleTheme';
+import { translateRole } from '@/lib/translateRole';
 import type { User } from '@/services/userService';
 import type { Opportunity } from '@/services/opportunityService';
 
@@ -30,6 +32,7 @@ function AssignModal({ student, open, onClose, opportunities }: {
     opportunities: Opportunity[];
 }) {
     const t = useTranslations('studentsDashboard');
+    const theme = useRoleTheme();
     const [selectedOpp, setSelectedOpp] = useState('');
     const [assigning, setAssigning] = useState(false);
     const [successMsg, setSuccessMsg] = useState('');
@@ -83,11 +86,11 @@ function AssignModal({ student, open, onClose, opportunities }: {
                     </button>
                 </div>
 
-                <div className="rounded-xl bg-blue-50 border border-blue-100 p-3">
-                    <p className="text-sm font-medium text-blue-700">
+                <div className={`rounded-xl ${theme.accentBg} border ${theme.borderLight} p-3`}>
+                    <p className={`text-sm font-medium ${theme.accentText}`}>
                         {student.first_name} {student.last_name}
                     </p>
-                    <p className="text-xs text-blue-500">{student.email}</p>
+                    <p className={`text-xs ${theme.accent}`}>{student.email}</p>
                 </div>
 
                 <div>
@@ -101,7 +104,7 @@ function AssignModal({ student, open, onClose, opportunities }: {
                             <select
                                 value={selectedOpp}
                                 onChange={(e) => setSelectedOpp(e.target.value)}
-                                className="w-full appearance-none rounded-xl border border-gray-200 bg-white px-3 py-2 pr-8 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-200 focus:border-blue-400 transition-colors cursor-pointer"
+                                className={`w-full appearance-none rounded-xl border border-gray-200 bg-white px-3 py-2 pr-8 text-sm text-gray-700 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors cursor-pointer`}
                             >
                                 <option value="">{t('selectOpportunityPlaceholder')}</option>
                                 {openOpportunities.map((opp) => (
@@ -141,8 +144,8 @@ function AssignModal({ student, open, onClose, opportunities }: {
                         disabled={!selectedOpp || assigning || openOpportunities.length === 0}
                         className={`px-4 py-2 rounded-xl text-sm font-medium text-white transition-colors ${
                             !selectedOpp || assigning || openOpportunities.length === 0
-                                ? 'bg-blue-400 cursor-not-allowed opacity-60'
-                                : 'bg-blue-600 hover:bg-blue-700 cursor-pointer'
+                                ? `${theme.btnDisabled} cursor-not-allowed opacity-60`
+                                : `${theme.btnPrimary} ${theme.btnPrimaryHover} cursor-pointer`
                         }`}
                     >
                         {assigning ? t('assigning') : t('assign')}
@@ -157,6 +160,8 @@ function AssignModal({ student, open, onClose, opportunities }: {
 
 export default function StudentTable({ users, opportunities }: { users: User[]; opportunities: Opportunity[] }) {
     const t = useTranslations('studentsDashboard');
+    const tRoles = useTranslations('roles');
+    const theme = useRoleTheme();
     const [assignStudent, setAssignStudent] = useState<User | null>(null);
     const [searchQuery, setSearchQuery] = useState('');
     const [page, setPage] = useState(1);
@@ -228,7 +233,7 @@ export default function StudentTable({ users, opportunities }: { users: User[]; 
                                         <td className="py-4">
                                             <button
                                                 onClick={() => setAssignStudent(student)}
-                                                className="px-3 py-1.5 rounded-lg text-xs font-semibold text-blue-700 bg-blue-50 hover:bg-blue-100 transition-colors cursor-pointer"
+                                                className={`px-3 py-1.5 rounded-lg text-xs font-semibold ${theme.accentText} ${theme.accentBg} ${theme.softHover} transition-colors cursor-pointer`}
                                             >
                                                 {t('assignBtn')}
                                             </button>
@@ -248,7 +253,7 @@ export default function StudentTable({ users, opportunities }: { users: User[]; 
                                         {student.first_name} {student.last_name}
                                     </p>
                                     <span className="px-2 py-0.5 rounded-lg text-xs font-semibold bg-emerald-100 text-emerald-700">
-                                        {student.role?.name ?? t('student')}
+                                        {translateRole(student.role?.name, tRoles)}
                                     </span>
                                 </div>
                                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-1.5 text-sm">
@@ -276,7 +281,7 @@ export default function StudentTable({ users, opportunities }: { users: User[]; 
                                 <div className="flex justify-end border-t border-gray-50 pt-2">
                                     <button
                                         onClick={() => setAssignStudent(student)}
-                                        className="px-3 py-1.5 rounded-lg text-xs font-semibold text-blue-700 bg-blue-50 hover:bg-blue-100 transition-colors cursor-pointer"
+                                        className={`px-3 py-1.5 rounded-lg text-xs font-semibold ${theme.accentText} ${theme.accentBg} ${theme.softHover} transition-colors cursor-pointer`}
                                     >
                                         {t('assignBtn')}
                                     </button>

--- a/components/ui/DashboardCalendar.tsx
+++ b/components/ui/DashboardCalendar.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
+import { useRoleTheme } from '@/hooks/useRoleTheme';
 
 /* ── Helpers ─────────────────────────────────────────────── */
 
@@ -31,6 +32,7 @@ const WEEKDAYS_SHORT: Record<string, string[]> = {
 export default function DashboardCalendar() {
     const locale = useLocale();
     const t = useTranslations('dashboard');
+    const theme = useRoleTheme();
     const today = new Date();
     const [year, setYear] = useState(today.getFullYear());
     const [month, setMonth] = useState(today.getMonth());
@@ -89,7 +91,7 @@ export default function DashboardCalendar() {
                     <h2 className="text-lg font-semibold text-gray-800">{monthLabel}</h2>
                     <button
                         onClick={goToday}
-                        className="text-xs text-blue-600 hover:text-blue-700 font-medium px-2 py-0.5 rounded-md hover:bg-blue-50 transition-colors cursor-pointer"
+                        className={`text-xs ${theme.accent} ${theme.accentHover} font-medium px-2 py-0.5 rounded-md ${theme.accentBgHover} transition-colors cursor-pointer`}
                     >
                         {t('calendarToday')}
                     </button>
@@ -139,7 +141,7 @@ export default function DashboardCalendar() {
                                                 ? 'bg-gray-50/50'
                                                 : isWeekend
                                                   ? 'bg-gray-50/30'
-                                                  : 'hover:bg-blue-50/30'
+                                                  : theme.hoverSoftBgHalf
                                         }`}
                                     >
                                         {day !== null && (
@@ -147,7 +149,7 @@ export default function DashboardCalendar() {
                                                 <span
                                                     className={`text-sm font-medium inline-flex items-center justify-center w-7 h-7 rounded-full ${
                                                         todayCell
-                                                            ? 'bg-blue-600 text-white'
+                                                            ? `${theme.btnPrimary} text-white`
                                                             : isWeekend
                                                               ? 'text-gray-300'
                                                               : 'text-gray-600'

--- a/components/ui/FilterBar.tsx
+++ b/components/ui/FilterBar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
 import { useRoleTheme } from '@/hooks/useRoleTheme';
 import type { RoleTheme } from '@/hooks/useRoleTheme';
 
@@ -205,11 +206,15 @@ export default function FilterBar({
     onSearchChange,
     searchPlaceholder = '',
     filters = [],
-    filterLabel = 'Filters',
-    clearLabel = 'Clear filters',
-    applyLabel = 'Apply filters',
+    filterLabel: filterLabelProp,
+    clearLabel: clearLabelProp,
+    applyLabel: applyLabelProp,
     actionButton,
 }: FilterBarProps) {
+    const tCommon = useTranslations('common');
+    const filterLabel = filterLabelProp ?? tCommon('filters');
+    const clearLabel = clearLabelProp ?? tCommon('clearFilters');
+    const applyLabel = applyLabelProp ?? tCommon('applyFilters');
     const theme = useRoleTheme();
     const [open, setOpen] = useState(false);
     const [visible, setVisible] = useState(false);   // keeps modal mounted during exit animation

--- a/components/ui/Pagination.tsx
+++ b/components/ui/Pagination.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useTranslations } from 'next-intl';
+import { useRoleTheme } from '@/hooks/useRoleTheme';
 
 interface PaginationProps {
     page: number;
@@ -12,6 +13,7 @@ interface PaginationProps {
 
 export default function Pagination({ page, totalPages, totalItems, pageSize, onPageChange }: PaginationProps) {
     const t = useTranslations('table');
+    const theme = useRoleTheme();
 
     if (totalPages <= 1) return null;
 
@@ -75,7 +77,7 @@ export default function Pagination({ page, totalPages, totalItems, pageSize, onP
                             onClick={() => onPageChange(item)}
                             className={`w-8 h-8 text-sm rounded-lg font-medium transition-colors cursor-pointer ${
                                 page === item
-                                    ? 'bg-blue-600 text-white'
+                                    ? `${theme.btnPrimary} text-white`
                                     : 'text-gray-500 hover:bg-gray-100'
                             }`}
                         >

--- a/hooks/useRoleTheme.ts
+++ b/hooks/useRoleTheme.ts
@@ -48,6 +48,7 @@ const adminTheme = {
     checkboxBg: 'bg-purple-600 border-purple-600',
     badgeBg: 'bg-purple-600',
     softBgHalf: 'bg-purple-50/30',
+    hoverSoftBgHalf: 'hover:bg-purple-50/30',
 };
 
 const studentTheme = {
@@ -88,6 +89,7 @@ const studentTheme = {
     checkboxBg: 'bg-emerald-600 border-emerald-600',
     badgeBg: 'bg-emerald-600',
     softBgHalf: 'bg-emerald-50/30',
+    hoverSoftBgHalf: 'hover:bg-emerald-50/30',
 };
 
 const teacherTheme = {
@@ -128,6 +130,7 @@ const teacherTheme = {
     checkboxBg: 'bg-blue-600 border-blue-600',
     badgeBg: 'bg-blue-600',
     softBgHalf: 'bg-blue-50/30',
+    hoverSoftBgHalf: 'hover:bg-blue-50/30',
 };
 
 // Default & Lector: light gray
@@ -169,6 +172,7 @@ const defaultTheme = {
     checkboxBg: 'bg-gray-500 border-gray-500',
     badgeBg: 'bg-gray-500',
     softBgHalf: 'bg-gray-50/30',
+    hoverSoftBgHalf: 'hover:bg-gray-50/30',
 };
 
 export type RoleTheme = typeof adminTheme;

--- a/lib/translateRole.ts
+++ b/lib/translateRole.ts
@@ -1,0 +1,16 @@
+/**
+ * Translates a backend role name using the `roles` translation namespace.
+ *
+ * Usage:
+ *   const tRoles = useTranslations('roles');
+ *   translateRole(user.role?.name, tRoles);
+ */
+export function translateRole(
+    roleName: string | undefined | null,
+    t: { (key: string): string; has(key: string): boolean },
+): string {
+    if (!roleName) return t('noRole');
+    const key = roleName.toLowerCase();
+    if (t.has(key)) return t(key);
+    return roleName;
+}

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -64,7 +64,10 @@
     "loading": "Načítání...",
     "unknownError": "Neznámá chyba",
     "yes": "Ano",
-    "no": "Ne"
+    "no": "Ne",
+    "filters": "Filtry",
+    "clearFilters": "Vymazat filtry",
+    "applyFilters": "Použít filtry"
   },
 
   "dashboard": {
@@ -364,6 +367,19 @@
     "errorDescription": "Došlo k neočekávané chybě. Zkuste to prosím znovu.",
     "errorRetry": "Zkusit znovu",
     "errorGoHome": "Na úvod"
+  },
+
+  "roles": {
+    "admin": "Administrátor",
+    "administrator": "Administrátor",
+    "student": "Student",
+    "teacher": "Učitel",
+    "profesor": "Učitel",
+    "coordinador": "Koordinátor",
+    "coordinator": "Koordinátor",
+    "lector": "Lektor",
+    "reader": "Čtenář",
+    "noRole": "Bez role"
   },
 
   "accessDenied": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -64,7 +64,10 @@
     "loading": "Loading...",
     "unknownError": "Unknown error",
     "yes": "Yes",
-    "no": "No"
+    "no": "No",
+    "filters": "Filters",
+    "clearFilters": "Clear filters",
+    "applyFilters": "Apply filters"
   },
 
   "dashboard": {
@@ -364,6 +367,19 @@
     "errorDescription": "An unexpected error occurred. Please try again.",
     "errorRetry": "Try again",
     "errorGoHome": "Go home"
+  },
+
+  "roles": {
+    "admin": "Administrator",
+    "administrator": "Administrator",
+    "student": "Student",
+    "teacher": "Teacher",
+    "profesor": "Teacher",
+    "coordinador": "Coordinator",
+    "coordinator": "Coordinator",
+    "lector": "Lector",
+    "reader": "Reader",
+    "noRole": "No role"
   },
 
   "accessDenied": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -64,7 +64,10 @@
     "loading": "Cargando...",
     "unknownError": "Error desconocido",
     "yes": "Sí",
-    "no": "No"
+    "no": "No",
+    "filters": "Filtros",
+    "clearFilters": "Limpiar filtros",
+    "applyFilters": "Aplicar filtros"
   },
 
   "dashboard": {
@@ -364,6 +367,19 @@
     "errorDescription": "Ha ocurrido un error inesperado. Por favor, inténtalo de nuevo.",
     "errorRetry": "Reintentar",
     "errorGoHome": "Ir al inicio"
+  },
+
+  "roles": {
+    "admin": "Administrador",
+    "administrator": "Administrador",
+    "student": "Estudiante",
+    "teacher": "Profesor",
+    "profesor": "Profesor",
+    "coordinador": "Coordinador",
+    "coordinator": "Coordinador",
+    "lector": "Lector",
+    "reader": "Lector",
+    "noRole": "Sin rol"
   },
 
   "accessDenied": {

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Introduce translateRole util and integrate role-based theme/styles across dashboard components. Rework UI pieces to use useRoleTheme (forms, tables, modals, calendar, pagination, buttons) and replace hardcoded role labels with translated values. Add 'roles' translations and common filter labels to en/cs/es locale files. Small UX refactor: redesigned welcome header, replace custom unauthorized markup with AccessDenied component, and tweak hover/soft-bg theme tokens in useRoleTheme. Also update next-env import path to .next/dev/types/routes.d.ts.

## ✨ Descripción
(Describe brevemente qué añade o corrige este Pull Request.)

## 🔗 Issue relacionado
Fixes #23 
<!-- Ejemplo: Fixes #21 -->

---