### PR TITLE
Convert students page to client with assign modal

### DIFF
--- a/app/[locale]/(dashboard)/dashboard/students/page.tsx
+++ b/app/[locale]/(dashboard)/dashboard/students/page.tsx
@@ -1,62 +1,442 @@
-import { cookies } from 'next/headers';
-import { redirect } from 'next/navigation';
-import { getTranslations } from 'next-intl/server';
-import { fetchUsersServer } from '@/services/userService';
-import { fetchOpportunitiesServer } from '@/services/opportunityService';
-import StudentTable from '@/components/students/StudentTable';
-import StatCards from '@/components/ui/StatCards';
-import RoleGuard from '@/components/ui/RoleGuard';
+"use client";
 
-export default async function StudentsPage({ params }: { params: Promise<{ locale: string }> }) {
-    const { locale } = await params;
-    const cookieStore = await cookies();
-    const token = cookieStore.get('auth_token')?.value;
+import { useState, useEffect } from "react";
+import { useTranslations } from "next-intl";
+import { useApi } from "@/hooks/useApi";
+import { useRoleTheme } from "@/hooks/useRoleTheme";
+import LoadingSpinner from "@/components/ui/LoadingSpinner";
+import Pagination from "@/components/ui/Pagination";
+import RoleGuard from "@/components/ui/RoleGuard";
+import Cookies from "js-cookie";
+import { API_URL } from "@/lib/api";
+import { GYMNASIUM_COURSES } from "../documents/constants";
+import type { Opportunity, PaginatedOpportunities } from "@/services/opportunityService";
 
-    if (!token) {
-        redirect(`/${locale}/login`);
-    }
+interface GradedUser {
+    id: number;
+    user_id: number;
+    first_name: string;
+    last_name: string;
+    year?: string | null;
+    final_grade: number | null;
+}
 
-    const t = await getTranslations('studentsDashboard');
-    const [users, opportunities] = await Promise.all([
-        fetchUsersServer(token),
-        fetchOpportunitiesServer(token),
-    ]);
+interface UserMin {
+    id: number;
+    role?: { name: string } | null;
+}
 
-    // Count eligible students (adults with Student role, excluding lector)
-    const eligibleStudents = users.filter(u => {
-        const role = u.role?.name?.toLowerCase() || '';
-        return role.includes('student') && !u.is_minor && !role.includes('lector');
-    });
+const PAGE_SIZE = 15;
+
+/* ── Assign modal ─────────────────────────────────────────────────────────── */
+
+function AssignModal({ student, onClose, opportunities, currentOpp, resolvedUserId }: {
+    student: GradedUser | null;
+    onClose: () => void;
+    opportunities: Opportunity[];
+    currentOpp?: string;
+    resolvedUserId?: number;
+}) {
+    const t = useTranslations("studentsDashboard");
+    const theme = useRoleTheme();
+    const [selectedOpp, setSelectedOpp] = useState("");
+    const [assigning, setAssigning] = useState(false);
+    const [successMsg, setSuccessMsg] = useState("");
+    const [errorMsg, setErrorMsg] = useState("");
+
+    useEffect(() => {
+        if (student) { setSelectedOpp(""); setSuccessMsg(""); setErrorMsg(""); }
+    }, [student]);
+
+    if (!student) return null;
+
+    const openOpportunities = opportunities.filter(o => o.status === "open");
+
+    const handleAssign = async () => {
+        if (!selectedOpp) return;
+        const userId = resolvedUserId ?? student.user_id;
+        if (!userId) { setErrorMsg(t("assignError")); return; }
+        setAssigning(true);
+        setErrorMsg("");
+        try {
+            const token = Cookies.get("auth_token");
+            const isReassign = !!currentOpp;
+            const res = await fetch(
+                isReassign ? `${API_URL}/applications/reassign` : `${API_URL}/applications/`,
+                {
+                    method: isReassign ? "PATCH" : "POST",
+                    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+                    body: isReassign
+                        ? JSON.stringify({ user_id: userId, new_opportunity_id: parseInt(selectedOpp) })
+                        : JSON.stringify({ opportunity_id: parseInt(selectedOpp), user_id: userId }),
+                }
+            );
+            if (res.ok) {
+                setSuccessMsg(t("assignSuccess"));
+                setTimeout(onClose, 1500);
+            } else {
+                const err = await res.json().catch(() => null);
+                const detail: string = err?.detail || "";
+                if (detail === "Opportunity not found") setErrorMsg(t("errorOpportunityNotFound"));
+                else if (detail === "This opportunity is not open for applications") setErrorMsg(t("errorOpportunityNotOpen"));
+                else if (detail === "No available slots for this opportunity") setErrorMsg(t("errorNoAvailableSlots"));
+                else if (detail === "You already have an application for this opportunity") setErrorMsg(t("errorAlreadyApplied"));
+                else setErrorMsg(t("assignError"));
+            }
+        } catch {
+            setErrorMsg(t("assignError"));
+        } finally {
+            setAssigning(false);
+        }
+    };
 
     return (
-        <RoleGuard allowed={['admin', 'teacher']}>
-        <div className="space-y-6">
-            <StatCards items={[
-                {
-                    label: t('eligibleStudents'),
-                    value: eligibleStudents.length,
-                    color: 'text-emerald-600',
-                    icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-5 h-5"><path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clipRule="evenodd" /></svg>,
-                },
-                {
-                    label: t('totalStudents'),
-                    value: users.filter(u => u.role?.name?.toLowerCase().includes('student')).length,
-                    icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-5 h-5"><path d="M10 9a3 3 0 100-6 3 3 0 000 6zM6 8a2 2 0 11-4 0 2 2 0 014 0zM1.49 15.326a.78.78 0 01-.358-.442 3 3 0 014.308-3.516 6.484 6.484 0 00-1.905 3.959c-.023.222-.014.442.025.654a4.97 4.97 0 01-2.07-.655zM16.44 15.98a4.97 4.97 0 002.07-.654.78.78 0 00.357-.442 3 3 0 00-4.308-3.517 6.484 6.484 0 011.907 3.96 2.32 2.32 0 01-.026.654zM18 8a2 2 0 11-4 0 2 2 0 014 0zM5.304 16.19a.844.844 0 01-.277-.71 5 5 0 019.947 0 .843.843 0 01-.277.71A6.975 6.975 0 0110 18a6.975 6.975 0 01-4.696-1.81z" /></svg>,
-                },
-            ]} />
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+            <div className="fixed inset-0 bg-black/40 backdrop-blur-sm" onClick={onClose} />
+            <div className="relative bg-white dark:bg-gray-900 rounded-2xl shadow-xl w-full max-w-md p-6">
 
-            {/* Students section */}
-            <div className="bg-white dark:bg-gray-900 rounded-3xl p-4 sm:p-8 border border-gray-100 dark:border-gray-800 shadow-sm">
-                <div className="flex justify-between items-center mb-6">
-                    <h2 className="text-xl sm:text-2xl font-bold text-gray-800 dark:text-gray-100">{t('title')}</h2>
-                    <span className="bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300 px-3 py-1 rounded-full text-sm font-medium">
-                        {eligibleStudents.length} {t('studentsLabel')}
-                    </span>
-                </div>
+                {successMsg ? (
+                    <div className="flex flex-col items-center justify-center py-8 gap-4">
+                        <div className="w-16 h-16 rounded-full bg-emerald-100 dark:bg-emerald-900/30 flex items-center justify-center">
+                            <svg className="w-8 h-8 text-emerald-600 dark:text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M5 13l4 4L19 7" />
+                            </svg>
+                        </div>
+                        <p className="text-base font-semibold text-gray-800 dark:text-gray-100 text-center">{successMsg}</p>
+                    </div>
+                ) : (
+                    <div className="space-y-4">
+                        <div className="flex items-center justify-between">
+                            <h3 className="text-lg font-bold text-gray-800 dark:text-gray-100">{currentOpp ? t("changeOpportunity") : t("assignToOpportunity")}</h3>
+                            <button onClick={onClose} className="p-1 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors cursor-pointer">
+                                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+                                </svg>
+                            </button>
+                        </div>
 
-                <StudentTable users={users} opportunities={opportunities} />
+                        <div className={`rounded-xl ${theme.accentBg} border ${theme.borderLight} p-3`}>
+                            <p className={`text-sm font-semibold ${theme.accentText}`}>{student.first_name} {student.last_name}</p>
+                        </div>
+
+                        {currentOpp && (
+                            <div className="flex items-center gap-2 rounded-xl bg-amber-50 dark:bg-amber-900/20 border border-amber-100 dark:border-amber-800 px-3 py-2.5">
+                                <svg className="w-4 h-4 text-amber-500 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                </svg>
+                                <p className="text-xs text-amber-700 dark:text-amber-400">
+                                    Ya asignado a <span className="font-semibold">{currentOpp}</span>
+                                </p>
+                            </div>
+                        )}
+
+                        <div>
+                            <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1.5">{t("selectOpportunity")}</label>
+                            {openOpportunities.length === 0 ? (
+                                <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-3 py-2.5 text-sm text-gray-400">
+                                    {t("noOpportunitiesYet")}
+                                </div>
+                            ) : (
+                                <select
+                                    value={selectedOpp}
+                                    onChange={e => setSelectedOpp(e.target.value)}
+                                    disabled={assigning}
+                                    className={`w-full appearance-none rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-700 dark:text-gray-200 focus:outline-none focus:ring-2 ${theme.focusRing} cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed`}
+                                >
+                                    <option value="">{t("selectOpportunityPlaceholder")}</option>
+                                    {openOpportunities.map(opp => (
+                                        <option key={opp.id} value={opp.id.toString()}>
+                                            {opp.name}{opp.city ? ` — ${opp.city}` : ""}{opp.country ? `, ${opp.country}` : ""}
+                                        </option>
+                                    ))}
+                                </select>
+                            )}
+                        </div>
+
+                        {errorMsg && <div className="rounded-xl bg-red-50 dark:bg-red-900/20 border border-red-100 dark:border-red-800 p-3 text-sm text-red-700 dark:text-red-400 font-medium">{errorMsg}</div>}
+
+                        <div className="flex justify-end gap-2 pt-1">
+                            <button onClick={onClose} disabled={assigning} className="px-4 py-2 rounded-xl text-sm font-medium text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed">
+                                {t("cancel")}
+                            </button>
+                            <button
+                                onClick={handleAssign}
+                                disabled={!selectedOpp || assigning || openOpportunities.length === 0}
+                                className={`px-4 py-2 rounded-xl text-sm font-medium text-white transition-colors inline-flex items-center gap-2 ${
+                                    !selectedOpp || assigning || openOpportunities.length === 0
+                                        ? `${theme.btnDisabled} cursor-not-allowed opacity-60`
+                                        : `${theme.btnPrimary} ${theme.btnPrimaryHover} cursor-pointer`
+                                }`}
+                            >
+                                {assigning && (
+                                    <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                                    </svg>
+                                )}
+                                {assigning ? t("assigning") : t("assign")}
+                            </button>
+                        </div>
+                    </div>
+                )}
             </div>
         </div>
+    );
+}
+
+/* ── Page ─────────────────────────────────────────────────────────────────── */
+
+export default function StudentsPage() {
+    const t = useTranslations("studentsDashboard");
+    const theme = useRoleTheme();
+
+    const [search, setSearch] = useState("");
+    const [courseFilter, setCourseFilter] = useState("");
+    const [page, setPage] = useState(1);
+    const [assignStudent, setAssignStudent] = useState<GradedUser | null>(null);
+
+    const { data: finalList, loading, error } = useApi<GradedUser[]>("/final-list");
+    const { data: allUsers } = useApi<UserMin[]>("/users");
+    const { data: oppsData } = useApi<PaginatedOpportunities>("/opportunities?page=1&page_size=100");
+    const { data: allApplications, refetch: refetchApplications } = useApi<{ user_id: number; first_name: string; last_name: string; opportunity_name: string }[]>("/applications/all");
+
+    // Map "FirstName LastName" → { user_id from applications (always valid), opportunity_name }
+    const assignmentMap = new Map<string, { userId: number; oppName: string }>(
+        (allApplications ?? []).map(a => [`${a.first_name} ${a.last_name}`, { userId: a.user_id, oppName: a.opportunity_name }])
+    );
+
+    useEffect(() => { setPage(1); }, [search, courseFilter]);
+
+    const totalStudents = allUsers?.filter(u =>
+        u.role?.name?.toLowerCase().includes("student")
+    ).length ?? 0;
+
+    const students = finalList ?? [];
+    const opportunities = oppsData?.items ?? [];
+
+    const sorted = [...students].sort((a, b) =>
+        (b.final_grade ?? -Infinity) - (a.final_grade ?? -Infinity)
+    );
+
+    const fullName = (s: GradedUser) => `${s.first_name} ${s.last_name}`;
+
+    const filtered = sorted.filter(s => {
+        if (search && !fullName(s).toLowerCase().includes(search.toLowerCase())) return false;
+        if (courseFilter && s.year !== courseFilter) return false;
+        return true;
+    });
+
+    const totalPages = Math.ceil(filtered.length / PAGE_SIZE);
+    const paginated = filtered.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+    const courseLabel = (year?: string | null) =>
+        GYMNASIUM_COURSES.find(c => c.value === year)?.label ?? year ?? "—";
+
+    return (
+        <RoleGuard allowed={["admin", "teacher"]}>
+        <div className="space-y-6">
+
+            {/* Header */}
+            <div className="flex items-start justify-between">
+                <div>
+                    <h1 className="text-2xl font-bold text-gray-900 dark:text-white">{t("title")}</h1>
+                    <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t("finalListSubtitle")}</p>
+                </div>
+            </div>
+
+            {/* Stat cards */}
+            <div className="grid grid-cols-2 gap-4">
+                <div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 p-5 flex items-center gap-4">
+                    <div className="w-10 h-10 rounded-xl bg-gray-100 dark:bg-gray-800 flex items-center justify-center shrink-0">
+                        <svg className="w-5 h-5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
+                        </svg>
+                    </div>
+                    <div>
+                        <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">{t("totalStudents")}</p>
+                        <p className="text-2xl font-bold text-gray-800 dark:text-white">{totalStudents}</p>
+                    </div>
+                </div>
+                <div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 p-5 flex items-center gap-4">
+                    <div className="w-10 h-10 rounded-xl bg-emerald-50 dark:bg-emerald-900/20 flex items-center justify-center shrink-0">
+                        <svg className="w-5 h-5 text-emerald-600 dark:text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z" />
+                        </svg>
+                    </div>
+                    <div>
+                        <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">{t("inFinalList")}</p>
+                        <p className="text-2xl font-bold text-emerald-600 dark:text-emerald-400">{students.length}</p>
+                    </div>
+                </div>
+            </div>
+
+            {/* Table card */}
+            <div className="bg-white dark:bg-gray-900 rounded-3xl border border-gray-100 dark:border-gray-800 shadow-sm overflow-hidden">
+
+                {/* Filters bar */}
+                <div className="px-5 py-3.5 border-b border-gray-100 dark:border-gray-800 flex items-center gap-2 flex-wrap">
+                    <select
+                        value={courseFilter}
+                        onChange={e => setCourseFilter(e.target.value)}
+                        className={`appearance-none rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-200 focus:outline-none focus:ring-2 ${theme.focusRing} cursor-pointer transition-colors`}
+                    >
+                        <option value="">{t("selectCourse")}</option>
+                        {GYMNASIUM_COURSES.map(c => (
+                            <option key={c.value} value={c.value}>{c.label}</option>
+                        ))}
+                    </select>
+                    <div className="relative flex-1 min-w-[160px] max-w-xs">
+                        <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth="2">
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                        </svg>
+                        <input
+                            type="text"
+                            value={search}
+                            onChange={e => setSearch(e.target.value)}
+                            placeholder={t("searchPlaceholder")}
+                            className={`w-full rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 pl-8 pr-3 py-1.5 text-sm text-gray-700 dark:text-gray-200 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`}
+                        />
+                    </div>
+                    {(search || courseFilter) && (
+                        <span className="text-xs text-gray-400 dark:text-gray-500 ml-auto">
+                            {filtered.length} resultado{filtered.length !== 1 ? "s" : ""}
+                        </span>
+                    )}
+                </div>
+
+                {/* Content */}
+                {loading ? (
+                    <div className="flex items-center justify-center h-48">
+                        <LoadingSpinner />
+                    </div>
+                ) : error ? (
+                    <div className="p-12 text-center">
+                        <svg className="w-10 h-10 text-gray-300 dark:text-gray-600 mx-auto mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        </svg>
+                        <p className="text-sm text-gray-400 dark:text-gray-500">{t("errorLoad")}</p>
+                    </div>
+                ) : filtered.length === 0 ? (
+                    <div className="p-12 text-center">
+                        <svg className="w-10 h-10 text-gray-300 dark:text-gray-600 mx-auto mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                        </svg>
+                        <p className="text-sm text-gray-400 dark:text-gray-500">
+                            {search || courseFilter ? t("noResults") : t("finalListEmpty")}
+                        </p>
+                    </div>
+                ) : (
+                    <>
+                        <div className="overflow-x-auto">
+                            <table className="w-full">
+                                <thead>
+                                    <tr className="bg-gray-50 dark:bg-gray-800/60">
+                                        <th className="text-center text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider px-4 py-3 w-14">
+                                            {t("colPosition")}
+                                        </th>
+                                        <th className="text-left text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider px-5 py-3">
+                                            {t("colName")}
+                                        </th>
+                                        <th className="text-left text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider px-5 py-3">
+                                            {t("colCourse")}
+                                        </th>
+                                        <th className="text-center text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider px-5 py-3">
+                                            {t("colGrade")}
+                                        </th>
+                                        <th className="text-left text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider px-5 py-3">
+                                            {t("assignToOpportunity")}
+                                        </th>
+                                        <th className="px-5 py-3 w-36" />
+                                    </tr>
+                                </thead>
+                                <tbody className="divide-y divide-gray-50 dark:divide-gray-800">
+                                    {paginated.map(s => {
+                                        const position = filtered.indexOf(s) + 1;
+                                        const isTop3 = position <= 3;
+                                        const appInfo = assignmentMap.get(`${s.first_name} ${s.last_name}`);
+                                        const assignedOpp = appInfo?.oppName;
+                                        return (
+                                            <tr key={s.id} className={`group transition-colors hover:bg-gray-50 dark:hover:bg-gray-800/40 ${isTop3 ? "bg-gradient-to-r from-transparent to-transparent" : ""}`}>
+                                                <td className="px-4 py-3.5 text-center">
+                                                    <span className={`inline-flex items-center justify-center w-7 h-7 rounded-full text-xs font-bold ${
+                                                        position === 1 ? "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-400 ring-1 ring-yellow-200 dark:ring-yellow-700/50" :
+                                                        position === 2 ? "bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 ring-1 ring-gray-200 dark:ring-gray-600" :
+                                                        position === 3 ? "bg-orange-100 dark:bg-orange-900/30 text-orange-600 dark:text-orange-400 ring-1 ring-orange-200 dark:ring-orange-700/50" :
+                                                        "text-gray-400 dark:text-gray-500"
+                                                    }`}>
+                                                        {position}
+                                                    </span>
+                                                </td>
+                                                <td className="px-5 py-3.5">
+                                                    <p className="text-sm font-semibold text-gray-800 dark:text-gray-100">{fullName(s)}</p>
+                                                </td>
+                                                <td className="px-5 py-3.5">
+                                                    <span className="inline-flex items-center gap-1 text-xs font-medium px-2 py-1 rounded-lg bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400">
+                                                        <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 14l9-5-9-5-9 5 9 5z" />
+                                                        </svg>
+                                                        {courseLabel(s.year)}
+                                                    </span>
+                                                </td>
+                                                <td className="px-5 py-3.5 text-center">
+                                                    {s.final_grade != null ? (
+                                                        <span className={`inline-flex items-center justify-center px-3 py-1 rounded-full text-sm font-bold ${theme.accentBg} ${theme.accentText}`}>
+                                                            {s.final_grade}
+                                                        </span>
+                                                    ) : (
+                                                        <span className="text-gray-300 dark:text-gray-600 text-sm">—</span>
+                                                    )}
+                                                </td>
+                                                <td className="px-5 py-3.5">
+                                                    {assignedOpp ? (
+                                                        <span className="inline-flex items-center gap-1.5 text-xs font-medium px-2.5 py-1 rounded-lg bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-400 border border-emerald-100 dark:border-emerald-800">
+                                                            <svg className="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7" />
+                                                            </svg>
+                                                            {assignedOpp}
+                                                        </span>
+                                                    ) : (
+                                                        <span className="text-gray-300 dark:text-gray-600 text-xs">—</span>
+                                                    )}
+                                                </td>
+                                                <td className="px-5 py-3.5 text-right">
+                                                    <button
+                                                        onClick={() => setAssignStudent(s)}
+                                                        className={`whitespace-nowrap px-3 py-1.5 rounded-lg text-xs font-semibold transition-colors cursor-pointer ${theme.accentText} ${theme.accentBg} ${theme.softHover}`}
+                                                    >
+                                                        {assignedOpp ? t("changeOpportunity") : t("assignBtn")}
+                                                    </button>
+                                                </td>
+                                            </tr>
+                                        );
+                                    })}
+                                </tbody>
+                            </table>
+                        </div>
+
+                        {totalPages > 1 && (
+                            <div className="px-5 py-3 border-t border-gray-100 dark:border-gray-800">
+                                <Pagination
+                                    page={page}
+                                    totalPages={totalPages}
+                                    totalItems={filtered.length}
+                                    pageSize={PAGE_SIZE}
+                                    onPageChange={setPage}
+                                />
+                            </div>
+                        )}
+                    </>
+                )}
+            </div>
+        </div>
+
+        <AssignModal
+            student={assignStudent}
+            onClose={() => { setAssignStudent(null); refetchApplications(); }}
+            opportunities={opportunities}
+            currentOpp={assignStudent ? assignmentMap.get(`${assignStudent.first_name} ${assignStudent.last_name}`)?.oppName : undefined}
+            resolvedUserId={assignStudent ? assignmentMap.get(`${assignStudent.first_name} ${assignStudent.last_name}`)?.userId : undefined}
+        />
         </RoleGuard>
     );
 }

--- a/components/layout/DashboardSidebar.tsx
+++ b/components/layout/DashboardSidebar.tsx
@@ -16,8 +16,29 @@ import ConfirmModal from '@/components/ui/ConfirmModal';
 export default function DashboardSidebar() {
     // Estado para el proceso de selección
     const [isProcessStarted, setIsProcessStarted] = useState(false);
+    const [isTogglingProcess, setIsTogglingProcess] = useState(false);
     // Estado para el modal de confirmación
     const [showConfirmModal, setShowConfirmModal] = useState(false);
+
+    const handleToggleProcess = async () => {
+        setShowConfirmModal(false);
+        setIsTogglingProcess(true);
+        const wasActive = isProcessStarted;
+        try {
+            const data = await apiPost<{ active: boolean }>('/selection-process/toggle', {});
+            setIsProcessStarted(data.active);
+            if (!wasActive && data.active) {
+                await apiPost('/notifications/broadcast', {
+                    message_key: 'selection_process_started',
+                    type: 'application_update',
+                });
+            }
+        } catch (error) {
+            console.error('Error toggling process:', error);
+        } finally {
+            setIsTogglingProcess(false);
+        }
+    };
 
     const t = useTranslations('dashboard');
     const tp = useTranslations('practicas');
@@ -222,18 +243,26 @@ export default function DashboardSidebar() {
 
                             {isAdmin && (
                                 <button
-                                    onClick={() => setShowConfirmModal(true)}
-                                    className={`flex items-center gap-3 px-3 py-2.5 mt-6 w-full rounded-lg transition-all duration-200 ${isProcessStarted ? 'text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-500/10' : 'text-emerald-600 dark:text-emerald-400 hover:bg-emerald-50 dark:hover:bg-emerald-500/10'}`}
+                                    onClick={() => !isTogglingProcess && setShowConfirmModal(true)}
+                                    disabled={isTogglingProcess}
+                                    className={`flex items-center gap-3 px-3 py-2.5 mt-6 w-full rounded-lg transition-all duration-200 disabled:opacity-60 disabled:cursor-not-allowed ${isProcessStarted ? 'text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-500/10' : 'text-emerald-600 dark:text-emerald-400 hover:bg-emerald-50 dark:hover:bg-emerald-500/10'}`}
                                 >
-                                    <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth="2">
-                                        {isProcessStarted ? (
-                                            <path strokeLinecap="round" strokeLinejoin="round" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z M9 10h6m-6 4h6" />
-                                        ) : (
-                                            <path strokeLinecap="round" strokeLinejoin="round" d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.971l-11.54 6.347a1.125 1.125 0 01-1.667-.985V5.653z" />
-                                        )}
-                                    </svg>
+                                    {isTogglingProcess ? (
+                                        <svg className="w-5 h-5 shrink-0 animate-spin" fill="none" viewBox="0 0 24 24">
+                                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                                            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                                        </svg>
+                                    ) : (
+                                        <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth="2">
+                                            {isProcessStarted ? (
+                                                <path strokeLinecap="round" strokeLinejoin="round" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z M9 10h6m-6 4h6" />
+                                            ) : (
+                                                <path strokeLinecap="round" strokeLinejoin="round" d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.971l-11.54 6.347a1.125 1.125 0 01-1.667-.985V5.653z" />
+                                            )}
+                                        </svg>
+                                    )}
                                     <span className={`text-sm font-semibold whitespace-nowrap transition-opacity duration-300 ${isCollapsed ? 'opacity-0' : 'opacity-100'}`}>
-                                        {isProcessStarted ? 'Detener proceso' : 'Empezar proceso'}
+                                        {isTogglingProcess ? 'Procesando...' : isProcessStarted ? 'Detener proceso' : 'Empezar proceso'}
                                     </span>
                                 </button>
                             )}
@@ -276,24 +305,7 @@ export default function DashboardSidebar() {
                 }
                 confirmLabel={isProcessStarted ? "Detener proceso" : "Iniciar proceso"}
                 cancelLabel="Cancelar"
-                onConfirm={async () => {
-                    const wasActive = isProcessStarted;
-                    try {
-                        const data = await apiPost<{ active: boolean }>('/selection-process/toggle', {});
-                        setIsProcessStarted(data.active);
-
-                        if (!wasActive && data.active) {
-                            await apiPost('/notifications/broadcast', {
-                                message_key: 'selection_process_started',
-                                type: 'application_update',
-                            });
-                        }
-                        setShowConfirmModal(false);
-                    } catch (error) {
-                        console.error('Error toggling process:', error);
-                        throw error; // Re-throw para que el modal maneje el error
-                    }
-                }}
+                onConfirm={handleToggleProcess}
                 onClose={() => setShowConfirmModal(false)}
             />
 

--- a/components/opportunities/OpportunityTable.tsx
+++ b/components/opportunities/OpportunityTable.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { useAuth } from '@/context/AuthContext';
 import { API_URL } from '@/lib/api';
 import { getCountryFlagUrl } from '@/lib/countryFlags';
+import { searchCountries } from '@/lib/countries';
 import FilterBar from '@/components/ui/FilterBar';
 import Pagination from '@/components/ui/Pagination';
 import { useRoleTheme } from '@/hooks/useRoleTheme';
@@ -98,53 +99,148 @@ function StudentPills({ students, t, theme, locale }: { students: AssignedStuden
     );
 }
 
+/* ── Country autocomplete ──────────────────────────────────── */
+
+function CountryInput({ value, onChange, onRawChange, placeholder, inputCls, locale }: {
+    value: string;
+    onChange: (code: string) => void;
+    /** Called with the raw text the user is typing (even before selecting from list) */
+    onRawChange?: (raw: string) => void;
+    placeholder?: string;
+    inputCls: string;
+    locale: string;
+}) {
+    const [query, setQuery] = useState(value);
+    const [open, setOpen] = useState(false);
+    const ref = useRef<HTMLDivElement>(null);
+    const lang = locale === "cs" ? "cs" : locale === "es" ? "es" : "en";
+
+    // Sync query when value resets (e.g. modal opens)
+    useEffect(() => { setQuery(value); }, [value]);
+
+    // Close on outside click
+    useEffect(() => {
+        const handler = (e: MouseEvent) => {
+            if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+        };
+        document.addEventListener('mousedown', handler);
+        return () => document.removeEventListener('mousedown', handler);
+    }, []);
+
+    const results = searchCountries(query, locale);
+
+    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const raw = e.target.value;
+        setQuery(raw);
+        setOpen(true);
+        onChange('');          // Clear confirmed code — user is typing something new
+        onRawChange?.(raw);
+    };
+
+    const handleSelect = (code: string, name: string) => {
+        onChange(code);
+        setQuery(name);
+        onRawChange?.(name);
+        setOpen(false);
+    };
+
+    return (
+        <div ref={ref} className="relative">
+            <input
+                type="text"
+                value={query}
+                onChange={handleInputChange}
+                onFocus={() => query && setOpen(true)}
+                placeholder={placeholder}
+                className={inputCls}
+                autoComplete="off"
+            />
+            {open && results.length > 0 && (
+                <div className="absolute z-50 mt-1 w-full bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-lg max-h-48 overflow-y-auto">
+                    {results.map(c => (
+                        <button
+                            key={c.code}
+                            type="button"
+                            onMouseDown={() => handleSelect(c.code, c[lang])}
+                            className="w-full flex items-center gap-2.5 px-3 py-2 text-left hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+                        >
+                            {getCountryFlagUrl(c.code) && (
+                                <img src={getCountryFlagUrl(c.code)!} alt="" className="w-5 h-auto rounded-sm shrink-0" />
+                            )}
+                            <span className="text-sm text-gray-700 dark:text-gray-200 flex-1">{c[lang]}</span>
+                            <span className="text-xs text-gray-400 font-mono">{c.code}</span>
+                        </button>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}
+
 /* ── Create opportunity modal ──────────────────────────────── */
 
 function CreateModal({ open, onClose, onCreated }: { open: boolean; onClose: () => void; onCreated: () => void }) {
     const t = useTranslations('opportunitiesDashboard');
     const theme = useRoleTheme();
+    const params = useParams();
+    const locale = (params?.locale as string) || 'en';
     const [form, setForm] = useState({
         name: '', description: '', country: '', city: '',
-        max_slots: '1', start_date: '', end_date: '',
+        max_slots: 1, start_date: '', end_date: '',
     });
     const [creating, setCreating] = useState(false);
-    const [msg, setMsg] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+    const [success, setSuccess] = useState(false);
+    const [errorMsg, setErrorMsg] = useState('');
+    const [countryRaw, setCountryRaw] = useState('');
 
-    const updateField = (key: string, value: string) => setForm(f => ({ ...f, [key]: value }));
+    // Country is invalid when the user has typed something but hasn't selected from the list
+    const isCountryInvalid = !!countryRaw.trim() && !form.country;
+
+    const updateField = (key: string, value: string | number) => setForm(f => ({ ...f, [key]: value }));
+
+    // Reset when modal opens
+    useEffect(() => {
+        if (open) {
+            setForm({ name: '', description: '', country: '', city: '', max_slots: 1, start_date: '', end_date: '' });
+            setSuccess(false);
+            setErrorMsg('');
+            setCountryRaw('');
+        }
+    }, [open]);
 
     const handleCreate = async () => {
         if (!form.name.trim()) return;
+        if (isCountryInvalid) {
+            setErrorMsg('Selecciona un país válido del listado de sugerencias.');
+            return;
+        }
         setCreating(true);
-        setMsg(null);
+        setErrorMsg('');
         try {
             const token = Cookies.get('auth_token');
-            const body: Record<string, unknown> = {
-                name: form.name,
-                description: form.description || null,
-                country: form.country || null,
-                city: form.city || null,
-                max_slots: parseInt(form.max_slots) || 1,
-                status: 'open',
-                start_date: form.start_date || null,
-                end_date: form.end_date || null,
-            };
             const res = await fetch(`${API_URL}/opportunities/`, {
                 method: 'POST',
-                headers: {
-                    'Authorization': `Bearer ${token}`,
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify(body),
+                headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    name: form.name,
+                    description: form.description || null,
+                    country: form.country || null,
+                    city: form.city || null,
+                    max_slots: form.max_slots,
+                    status: 'open',
+                    start_date: form.start_date || null,
+                    end_date: form.end_date || null,
+                }),
             });
             if (res.ok) {
-                setMsg({ type: 'success', text: t('createSuccess') });
-                setTimeout(() => { onCreated(); onClose(); }, 1000);
+                setSuccess(true);
+                setTimeout(() => { onCreated(); onClose(); }, 1500);
             } else {
                 const err = await res.json().catch(() => null);
-                setMsg({ type: 'error', text: err?.detail || t('createError') });
+                setErrorMsg(err?.detail || t('createError'));
             }
         } catch {
-            setMsg({ type: 'error', text: t('createError') });
+            setErrorMsg(t('createError'));
         } finally {
             setCreating(false);
         }
@@ -152,79 +248,127 @@ function CreateModal({ open, onClose, onCreated }: { open: boolean; onClose: () 
 
     if (!open) return null;
 
+    const inputCls = `w-full rounded-xl border border-gray-200 dark:border-gray-700 px-3 py-2 text-sm text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors placeholder-gray-300 dark:placeholder-gray-600`;
+
     return (
-        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-            <div className="fixed inset-0 bg-black/40 backdrop-blur-sm" onClick={onClose} />
-            <div className="relative bg-white dark:bg-gray-900 rounded-2xl shadow-xl w-full max-w-lg p-6 space-y-4">
-                <div className="flex items-center justify-between">
-                    <h3 className="text-lg font-bold text-gray-800 dark:text-gray-100">{t('addTitle')}</h3>
-                    <button onClick={onClose} className="p-1 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-gray-300 transition-colors cursor-pointer">
-                        <XMarkIcon />
-                    </button>
-                </div>
+        <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center sm:p-4">
+            <div className="fixed inset-0 bg-black/40 backdrop-blur-sm" onClick={!creating ? onClose : undefined} />
+            <div className="relative bg-white dark:bg-gray-900 rounded-t-2xl sm:rounded-2xl shadow-xl w-full sm:max-w-md">
 
-                <div className="space-y-3">
-                    <div>
-                        <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">{t('fieldName')}</label>
-                        <input type="text" value={form.name} onChange={e => updateField('name', e.target.value)}
-                            placeholder={t('fieldNamePlaceholder')}
-                            className={`w-full rounded-xl border border-gray-200 dark:border-gray-700 px-3 py-2 text-sm text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`} />
-                    </div>
-                    <div>
-                        <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">{t('fieldDescription')}</label>
-                        <textarea value={form.description} onChange={e => updateField('description', e.target.value)}
-                            placeholder={t('fieldDescriptionPlaceholder')} rows={2}
-                            className={`w-full rounded-xl border border-gray-200 dark:border-gray-700 px-3 py-2 text-sm text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors resize-none`} />
-                    </div>
-                    <div className="grid grid-cols-2 gap-3">
-                        <div>
-                            <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">{t('fieldCountry')}</label>
-                            <input type="text" value={form.country} onChange={e => updateField('country', e.target.value)}
-                                placeholder={t('fieldCountryPlaceholder')}
-                                className={`w-full rounded-xl border border-gray-200 dark:border-gray-700 px-3 py-2 text-sm text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`} />
+                {success ? (
+                    <div className="flex flex-col items-center justify-center py-10 gap-3">
+                        <div className="w-14 h-14 rounded-full bg-emerald-100 dark:bg-emerald-900/30 flex items-center justify-center">
+                            <svg className="w-7 h-7 text-emerald-600 dark:text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M5 13l4 4L19 7" />
+                            </svg>
                         </div>
-                        <div>
-                            <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">{t('fieldCity')}</label>
-                            <input type="text" value={form.city} onChange={e => updateField('city', e.target.value)}
-                                placeholder={t('fieldCityPlaceholder')}
-                                className={`w-full rounded-xl border border-gray-200 dark:border-gray-700 px-3 py-2 text-sm text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`} />
+                        <div className="text-center">
+                            <p className="text-sm font-semibold text-gray-800 dark:text-gray-100">{t('createSuccess')}</p>
+                            <p className="text-xs text-gray-400 mt-0.5">{form.name}</p>
                         </div>
                     </div>
-                    <div className="grid grid-cols-3 gap-3">
-                        <div>
-                            <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">{t('fieldMaxSlots')}</label>
-                            <input type="number" min="1" value={form.max_slots} onChange={e => updateField('max_slots', e.target.value)}
-                                className={`w-full rounded-xl border border-gray-200 dark:border-gray-700 px-3 py-2 text-sm text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`} />
+                ) : (
+                    <div className="p-4 space-y-4">
+                        {/* Header */}
+                        <div className="flex items-center justify-between">
+                            <h3 className="text-base font-bold text-gray-800 dark:text-gray-100">{t('addTitle')}</h3>
+                            <button onClick={onClose} disabled={creating} className="p-1 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors cursor-pointer disabled:opacity-40">
+                                <XMarkIcon />
+                            </button>
                         </div>
-                        <div>
-                            <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">{t('fieldStartDate')}</label>
-                            <input type="date" value={form.start_date} onChange={e => updateField('start_date', e.target.value)}
-                                className={`w-full rounded-xl border border-gray-200 dark:border-gray-700 px-3 py-2 text-sm text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`} />
-                        </div>
-                        <div>
-                            <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">{t('fieldEndDate')}</label>
-                            <input type="date" value={form.end_date} onChange={e => updateField('end_date', e.target.value)}
-                                className={`w-full rounded-xl border border-gray-200 dark:border-gray-700 px-3 py-2 text-sm text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`} />
-                        </div>
-                    </div>
-                </div>
 
-                {msg && (
-                    <div className={`rounded-xl border p-3 text-sm font-medium ${msg.type === 'success' ? 'bg-emerald-50 border-emerald-100 text-emerald-700' : 'bg-red-50 border-red-100 text-red-700'}`}>
-                        {msg.text}
+                        {/* Nombre */}
+                        <div>
+                            <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
+                                {t('fieldName')} <span className="text-red-400">*</span>
+                            </label>
+                            <input type="text" value={form.name} onChange={e => updateField('name', e.target.value)}
+                                placeholder={t('fieldNamePlaceholder')} autoFocus className={inputCls} />
+                        </div>
+
+                        {/* Descripción */}
+                        <div>
+                            <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">{t('fieldDescription')}</label>
+                            <textarea value={form.description} onChange={e => updateField('description', e.target.value)}
+                                placeholder={t('fieldDescriptionPlaceholder')} rows={2}
+                                className={`${inputCls} resize-none`} />
+                        </div>
+
+                        {/* País + Ciudad */}
+                        <div className="grid grid-cols-2 gap-2">
+                            <div>
+                                <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">{t('fieldCountry')}</label>
+                                <CountryInput
+                                    value={form.country}
+                                    onChange={code => updateField('country', code)}
+                                    onRawChange={setCountryRaw}
+                                    placeholder="Ej: ES, DE, FR…"
+                                    inputCls={`${inputCls} ${isCountryInvalid ? 'border-red-400 dark:border-red-500 focus:ring-red-400' : ''}`}
+                                    locale={locale}
+                                />
+                                {isCountryInvalid && (
+                                    <p className="text-xs text-red-500 dark:text-red-400 mt-0.5">Selecciona del listado</p>
+                                )}
+                            </div>
+                            <div>
+                                <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">{t('fieldCity')}</label>
+                                <input type="text" value={form.city} onChange={e => updateField('city', e.target.value)}
+                                    placeholder="Madrid" className={inputCls} />
+                            </div>
+                        </div>
+
+                        {/* Plazas + Fechas en una fila */}
+                        <div className="grid grid-cols-[auto_1fr] gap-3 items-start">
+                            {/* Stepper plazas */}
+                            <div>
+                                <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">{t('fieldMaxSlots')}</label>
+                                <div className="flex items-center gap-1.5 h-9">
+                                    <button type="button" onClick={() => updateField('max_slots', Math.max(1, form.max_slots - 1))}
+                                        className="w-8 h-8 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-700 flex items-center justify-center cursor-pointer text-base leading-none">−</button>
+                                    <span className={`w-7 text-center text-sm font-bold ${theme.accentText}`}>{form.max_slots}</span>
+                                    <button type="button" onClick={() => updateField('max_slots', form.max_slots + 1)}
+                                        className="w-8 h-8 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-700 flex items-center justify-center cursor-pointer text-base leading-none">+</button>
+                                </div>
+                            </div>
+
+                            {/* Fechas estancia */}
+                            <div>
+                                <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
+                                    Estancia <span className="font-normal text-gray-400">(inicio → fin)</span>
+                                </label>
+                                <div className="grid grid-cols-2 gap-2">
+                                    <input type="date" value={form.start_date} onChange={e => updateField('start_date', e.target.value)}
+                                        className={inputCls} />
+                                    <input type="date" value={form.end_date} min={form.start_date || undefined} onChange={e => updateField('end_date', e.target.value)}
+                                        className={inputCls} />
+                                </div>
+                            </div>
+                        </div>
+
+                        {errorMsg && (
+                            <div className="rounded-xl bg-red-50 dark:bg-red-900/20 border border-red-100 dark:border-red-800 px-3 py-2 text-xs text-red-700 dark:text-red-400 font-medium">
+                                {errorMsg}
+                            </div>
+                        )}
+
+                        <div className="flex justify-end gap-2">
+                            <button onClick={onClose} disabled={creating}
+                                className="px-3 py-2 rounded-xl text-sm font-medium text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors cursor-pointer disabled:opacity-50">
+                                {t('cancel')}
+                            </button>
+                            <button onClick={handleCreate} disabled={!form.name.trim() || creating || isCountryInvalid}
+                                className={`px-4 py-2 rounded-xl text-sm font-medium text-white transition-colors inline-flex items-center gap-2 ${!form.name.trim() || creating || isCountryInvalid ? `${theme.btnDisabled} cursor-not-allowed opacity-60` : `${theme.btnPrimary} ${theme.btnPrimaryHover} cursor-pointer`}`}>
+                                {creating && (
+                                    <svg className="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24">
+                                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                                    </svg>
+                                )}
+                                {creating ? t('creating') : t('create')}
+                            </button>
+                        </div>
                     </div>
                 )}
-
-                <div className="flex justify-end gap-2 pt-2">
-                    <button onClick={onClose}
-                        className="px-4 py-2 rounded-xl text-sm font-medium text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors cursor-pointer">
-                        {t('cancel')}
-                    </button>
-                    <button onClick={handleCreate} disabled={!form.name.trim() || creating}
-                        className={`px-4 py-2 rounded-xl text-sm font-medium text-white transition-colors ${!form.name.trim() || creating ? `${theme.btnDisabled} cursor-not-allowed opacity-60` : `${theme.btnPrimary} ${theme.btnPrimaryHover} cursor-pointer`}`}>
-                        {creating ? t('creating') : t('create')}
-                    </button>
-                </div>
             </div>
         </div>
     );
@@ -235,12 +379,18 @@ function CreateModal({ open, onClose, onCreated }: { open: boolean; onClose: () 
 function EditModal({ opp, open, onClose, onUpdated }: { opp: OpportunityWithStudents | null; open: boolean; onClose: () => void; onUpdated: () => void }) {
     const t = useTranslations('opportunitiesDashboard');
     const theme = useRoleTheme();
+    const params = useParams();
+    const locale = (params?.locale as string) || 'en';
     const [form, setForm] = useState({
         name: '', description: '', country: '', city: '',
-        max_slots: '1', status: 'open', start_date: '', end_date: '',
+        max_slots: 1, status: 'open', start_date: '', end_date: '',
     });
     const [saving, setSaving] = useState(false);
-    const [msg, setMsg] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+    const [success, setSuccess] = useState(false);
+    const [errorMsg, setErrorMsg] = useState('');
+    const [countryRaw, setCountryRaw] = useState('');
+
+    const isCountryInvalid = !!countryRaw.trim() && !form.country;
 
     // Sync form when opp changes
     useEffect(() => {
@@ -250,50 +400,52 @@ function EditModal({ opp, open, onClose, onUpdated }: { opp: OpportunityWithStud
                 description: opp.description || '',
                 country: opp.country || '',
                 city: opp.city || '',
-                max_slots: String(opp.max_slots || 1),
+                max_slots: opp.max_slots || 1,
                 status: opp.status || 'open',
                 start_date: opp.start_date || '',
                 end_date: opp.end_date || '',
             });
-            setMsg(null);
+            setSuccess(false);
+            setErrorMsg('');
+            setCountryRaw(opp.country || '');
         }
     }, [opp?.id]);
 
-    const updateField = (key: string, value: string) => setForm(f => ({ ...f, [key]: value }));
+    const updateField = (key: string, value: string | number) => setForm(f => ({ ...f, [key]: value }));
 
     const handleSave = async () => {
         if (!opp || !form.name.trim()) return;
+        if (isCountryInvalid) {
+            setErrorMsg('Selecciona un país válido del listado de sugerencias.');
+            return;
+        }
         setSaving(true);
-        setMsg(null);
+        setErrorMsg('');
         try {
             const token = Cookies.get('auth_token');
-            const body: Record<string, unknown> = {
-                name: form.name,
-                description: form.description || null,
-                country: form.country || null,
-                city: form.city || null,
-                max_slots: parseInt(form.max_slots) || 1,
-                status: form.status,
-                start_date: form.start_date || null,
-                end_date: form.end_date || null,
-            };
             const res = await fetch(`${API_URL}/opportunities/${opp.id}`, {
                 method: 'PATCH',
-                headers: {
-                    'Authorization': `Bearer ${token}`,
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify(body),
+                headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    name: form.name,
+                    description: form.description || null,
+                    country: form.country || null,
+                    city: form.city || null,
+                    max_slots: form.max_slots,
+                    status: form.status,
+                    start_date: form.start_date || null,
+                    end_date: form.end_date || null,
+                }),
             });
             if (res.ok) {
-                setMsg({ type: 'success', text: t('editSuccess') });
-                setTimeout(() => { onUpdated(); onClose(); }, 1000);
+                setSuccess(true);
+                setTimeout(() => { onUpdated(); onClose(); }, 1500);
             } else {
                 const err = await res.json().catch(() => null);
-                setMsg({ type: 'error', text: err?.detail || t('editError') });
+                setErrorMsg(err?.detail || t('editError'));
             }
         } catch {
-            setMsg({ type: 'error', text: t('editError') });
+            setErrorMsg(t('editError'));
         } finally {
             setSaving(false);
         }
@@ -301,92 +453,142 @@ function EditModal({ opp, open, onClose, onUpdated }: { opp: OpportunityWithStud
 
     if (!open || !opp) return null;
 
-    return (
-        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-            <div className="fixed inset-0 bg-black/40 backdrop-blur-sm" onClick={onClose} />
-            <div className="relative bg-white dark:bg-gray-900 rounded-2xl shadow-xl w-full max-w-lg p-6 space-y-4">
-                <div className="flex items-center justify-between">
-                    <h3 className="text-lg font-bold text-gray-800 dark:text-gray-100">{t('editTitle')}</h3>
-                    <button onClick={onClose} className="p-1 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-gray-300 transition-colors cursor-pointer">
-                        <XMarkIcon />
-                    </button>
-                </div>
+    const inputCls = `w-full rounded-xl border border-gray-200 dark:border-gray-700 px-3 py-2 text-sm text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors placeholder-gray-300 dark:placeholder-gray-600`;
 
-                <div className="space-y-3">
-                    <div>
-                        <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">{t('fieldName')}</label>
-                        <input type="text" value={form.name} onChange={e => updateField('name', e.target.value)}
-                            placeholder={t('fieldNamePlaceholder')}
-                            className={`w-full rounded-xl border border-gray-200 dark:border-gray-700 px-3 py-2 text-sm text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`} />
-                    </div>
-                    <div>
-                        <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">{t('fieldDescription')}</label>
-                        <textarea value={form.description} onChange={e => updateField('description', e.target.value)}
-                            placeholder={t('fieldDescriptionPlaceholder')} rows={2}
-                            className={`w-full rounded-xl border border-gray-200 dark:border-gray-700 px-3 py-2 text-sm text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors resize-none`} />
-                    </div>
-                    <div className="grid grid-cols-2 gap-3">
-                        <div>
-                            <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">{t('fieldCountry')}</label>
-                            <input type="text" value={form.country} onChange={e => updateField('country', e.target.value)}
-                                placeholder={t('fieldCountryPlaceholder')}
-                                className={`w-full rounded-xl border border-gray-200 dark:border-gray-700 px-3 py-2 text-sm text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`} />
+    return (
+        <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center sm:p-4">
+            <div className="fixed inset-0 bg-black/40 backdrop-blur-sm" onClick={!saving ? onClose : undefined} />
+            <div className="relative bg-white dark:bg-gray-900 rounded-t-2xl sm:rounded-2xl shadow-xl w-full sm:max-w-md">
+
+                {success ? (
+                    <div className="flex flex-col items-center justify-center py-10 gap-3">
+                        <div className="w-14 h-14 rounded-full bg-emerald-100 dark:bg-emerald-900/30 flex items-center justify-center">
+                            <svg className="w-7 h-7 text-emerald-600 dark:text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M5 13l4 4L19 7" />
+                            </svg>
                         </div>
-                        <div>
-                            <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">{t('fieldCity')}</label>
-                            <input type="text" value={form.city} onChange={e => updateField('city', e.target.value)}
-                                placeholder={t('fieldCityPlaceholder')}
-                                className={`w-full rounded-xl border border-gray-200 dark:border-gray-700 px-3 py-2 text-sm text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`} />
+                        <div className="text-center">
+                            <p className="text-sm font-semibold text-gray-800 dark:text-gray-100">{t('editSuccess')}</p>
+                            <p className="text-xs text-gray-400 mt-0.5">{form.name}</p>
                         </div>
                     </div>
-                    <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-                        <div>
-                            <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">{t('fieldMaxSlots')}</label>
-                            <input type="number" min="1" value={form.max_slots} onChange={e => updateField('max_slots', e.target.value)}
-                                className={`w-full rounded-xl border border-gray-200 dark:border-gray-700 px-3 py-2 text-sm text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`} />
+                ) : (
+                    <div className="p-4 space-y-4">
+                        {/* Header */}
+                        <div className="flex items-center justify-between">
+                            <h3 className="text-base font-bold text-gray-800 dark:text-gray-100">{t('editTitle')}</h3>
+                            <button onClick={onClose} disabled={saving} className="p-1 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors cursor-pointer disabled:opacity-40">
+                                <XMarkIcon />
+                            </button>
                         </div>
+
+                        {/* Nombre */}
                         <div>
-                            <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">{t('status')}</label>
-                            <div className="relative">
-                                <select value={form.status} onChange={e => updateField('status', e.target.value)}
-                                    className={`w-full appearance-none rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 pr-8 text-sm text-gray-700 dark:text-gray-200 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors cursor-pointer`}>
-                                    <option value="open">{t('open')}</option>
-                                    <option value="closed">{t('closed')}</option>
-                                </select>
-                                <div className="absolute inset-y-0 right-2 flex items-center text-gray-400">
-                                    <ChevronDownIcon />
+                            <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
+                                {t('fieldName')} <span className="text-red-400">*</span>
+                            </label>
+                            <input type="text" value={form.name} onChange={e => updateField('name', e.target.value)}
+                                placeholder={t('fieldNamePlaceholder')} autoFocus className={inputCls} />
+                        </div>
+
+                        {/* Descripción */}
+                        <div>
+                            <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">{t('fieldDescription')}</label>
+                            <textarea value={form.description} onChange={e => updateField('description', e.target.value)}
+                                placeholder={t('fieldDescriptionPlaceholder')} rows={2}
+                                className={`${inputCls} resize-none`} />
+                        </div>
+
+                        {/* País + Ciudad */}
+                        <div className="grid grid-cols-2 gap-2">
+                            <div>
+                                <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">{t('fieldCountry')}</label>
+                                <CountryInput
+                                    value={form.country}
+                                    onChange={code => updateField('country', code)}
+                                    onRawChange={setCountryRaw}
+                                    placeholder="Ej: ES, DE, FR…"
+                                    inputCls={`${inputCls} ${isCountryInvalid ? 'border-red-400 dark:border-red-500 focus:ring-red-400' : ''}`}
+                                    locale={locale}
+                                />
+                                {isCountryInvalid && (
+                                    <p className="text-xs text-red-500 dark:text-red-400 mt-0.5">Selecciona del listado</p>
+                                )}
+                            </div>
+                            <div>
+                                <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">{t('fieldCity')}</label>
+                                <input type="text" value={form.city} onChange={e => updateField('city', e.target.value)}
+                                    placeholder="Madrid" className={inputCls} />
+                            </div>
+                        </div>
+
+                        {/* Plazas + Estado + Fechas */}
+                        <div className="grid grid-cols-[auto_auto_1fr] gap-3 items-start">
+                            {/* Stepper plazas */}
+                            <div>
+                                <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">{t('fieldMaxSlots')}</label>
+                                <div className="flex items-center gap-1.5 h-9">
+                                    <button type="button" onClick={() => updateField('max_slots', Math.max(1, form.max_slots - 1))}
+                                        className="w-8 h-8 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-700 flex items-center justify-center cursor-pointer text-base leading-none">−</button>
+                                    <span className={`w-7 text-center text-sm font-bold ${theme.accentText}`}>{form.max_slots}</span>
+                                    <button type="button" onClick={() => updateField('max_slots', form.max_slots + 1)}
+                                        className="w-8 h-8 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-700 flex items-center justify-center cursor-pointer text-base leading-none">+</button>
+                                </div>
+                            </div>
+
+                            {/* Estado */}
+                            <div>
+                                <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">{t('status')}</label>
+                                <div className="relative h-9">
+                                    <select value={form.status} onChange={e => updateField('status', e.target.value)}
+                                        className={`h-full w-full appearance-none rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 pr-7 text-sm text-gray-700 dark:text-gray-200 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors cursor-pointer`}>
+                                        <option value="open">{t('open')}</option>
+                                        <option value="closed">{t('closed')}</option>
+                                    </select>
+                                    <div className="pointer-events-none absolute inset-y-0 right-2 flex items-center text-gray-400">
+                                        <ChevronDownIcon />
+                                    </div>
+                                </div>
+                            </div>
+
+                            {/* Fechas estancia */}
+                            <div>
+                                <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
+                                    Estancia <span className="font-normal text-gray-400">(inicio → fin)</span>
+                                </label>
+                                <div className="grid grid-cols-2 gap-2">
+                                    <input type="date" value={form.start_date} onChange={e => updateField('start_date', e.target.value)}
+                                        className={inputCls} />
+                                    <input type="date" value={form.end_date} min={form.start_date || undefined} onChange={e => updateField('end_date', e.target.value)}
+                                        className={inputCls} />
                                 </div>
                             </div>
                         </div>
-                        <div>
-                            <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">{t('fieldStartDate')}</label>
-                            <input type="date" value={form.start_date} onChange={e => updateField('start_date', e.target.value)}
-                                className={`w-full rounded-xl border border-gray-200 dark:border-gray-700 px-3 py-2 text-sm text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`} />
-                        </div>
-                        <div>
-                            <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">{t('fieldEndDate')}</label>
-                            <input type="date" value={form.end_date} onChange={e => updateField('end_date', e.target.value)}
-                                className={`w-full rounded-xl border border-gray-200 dark:border-gray-700 px-3 py-2 text-sm text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 focus:outline-none focus:ring-2 ${theme.focusRing} transition-colors`} />
-                        </div>
-                    </div>
-                </div>
 
-                {msg && (
-                    <div className={`rounded-xl border p-3 text-sm font-medium ${msg.type === 'success' ? 'bg-emerald-50 border-emerald-100 text-emerald-700' : 'bg-red-50 border-red-100 text-red-700'}`}>
-                        {msg.text}
+                        {errorMsg && (
+                            <div className="rounded-xl bg-red-50 dark:bg-red-900/20 border border-red-100 dark:border-red-800 px-3 py-2 text-xs text-red-700 dark:text-red-400 font-medium">
+                                {errorMsg}
+                            </div>
+                        )}
+
+                        <div className="flex justify-end gap-2">
+                            <button onClick={onClose} disabled={saving}
+                                className="px-3 py-2 rounded-xl text-sm font-medium text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors cursor-pointer disabled:opacity-50">
+                                {t('cancel')}
+                            </button>
+                            <button onClick={handleSave} disabled={!form.name.trim() || saving || isCountryInvalid}
+                                className={`px-4 py-2 rounded-xl text-sm font-medium text-white transition-colors inline-flex items-center gap-2 ${!form.name.trim() || saving || isCountryInvalid ? `${theme.btnDisabled} cursor-not-allowed opacity-60` : `${theme.btnPrimary} ${theme.btnPrimaryHover} cursor-pointer`}`}>
+                                {saving && (
+                                    <svg className="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24">
+                                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                                    </svg>
+                                )}
+                                {saving ? t('saving') : t('save')}
+                            </button>
+                        </div>
                     </div>
                 )}
-
-                <div className="flex justify-end gap-2 pt-2">
-                    <button onClick={onClose}
-                        className="px-4 py-2 rounded-xl text-sm font-medium text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors cursor-pointer">
-                        {t('cancel')}
-                    </button>
-                    <button onClick={handleSave} disabled={!form.name.trim() || saving}
-                        className={`px-4 py-2 rounded-xl text-sm font-medium text-white transition-colors ${!form.name.trim() || saving ? `${theme.btnDisabled} cursor-not-allowed opacity-60` : `${theme.btnPrimary} ${theme.btnPrimaryHover} cursor-pointer`}`}>
-                        {saving ? t('saving') : t('save')}
-                    </button>
-                </div>
             </div>
         </div>
     );
@@ -400,6 +602,7 @@ export default function OpportunityTable({ opportunities }: { opportunities: Opp
     const theme = useRoleTheme();
     const params = useParams();
     const locale = (params?.locale as string) || 'en';
+    const dateLocale = locale === 'cs' ? 'cs-CZ' : locale === 'es' ? 'es-ES' : 'en-GB';
     const [searchQuery, setSearchQuery] = useState('');
     const [statusFilter, setStatusFilter] = useState('');
     const [countryFilter, setCountryFilter] = useState<string[]>([]);
@@ -535,7 +738,7 @@ export default function OpportunityTable({ opportunities }: { opportunities: Opp
                                         <td className="py-4 pr-6"><StatusPill status={opp.status} t={t} /></td>
                                         <td className="py-4 pr-6"><SlotsBar filled={opp.filled_slots} max={opp.max_slots} /></td>
                                         <td className="py-4 pr-6 text-gray-500 dark:text-gray-400 text-sm">
-                                            {opp.start_date ? new Date(opp.start_date).toLocaleDateString() : '—'}
+                                            {opp.start_date ? new Date(opp.start_date).toLocaleDateString(dateLocale) : '—'}
                                         </td>
                                         <td className="py-4"><StudentPills students={opp.students} t={t} theme={theme} locale={locale} /></td>
                                         {canManage && (
@@ -585,7 +788,7 @@ export default function OpportunityTable({ opportunities }: { opportunities: Opp
                                         <SlotsBar filled={opp.filled_slots} max={opp.max_slots} />
                                     </div>
                                     <span className="text-xs text-gray-400">
-                                        {opp.start_date ? new Date(opp.start_date).toLocaleDateString() : ''}
+                                        {opp.start_date ? new Date(opp.start_date).toLocaleDateString(dateLocale) : ''}
                                     </span>
                                 </div>
                                 <div>

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -423,6 +423,7 @@
     "createdAt": "Registrován",
     "assignBtn": "Přiřadit k příležitosti",
     "assignToOpportunity": "Přiřadit k příležitosti",
+    "changeOpportunity": "Změnit příležitost",
     "selectOpportunity": "Příležitost",
     "selectOpportunityPlaceholder": "Vyberte příležitost...",
     "noOpportunitiesYet": "Žádné otevřené příležitosti",
@@ -437,7 +438,17 @@
     "errorOpportunityNotFound": "Příležitost nenalezena.",
     "errorOpportunityNotOpen": "Tato příležitost není otevřena pro přihlášky.",
     "errorNoAvailableSlots": "Pro tuto příležitost nejsou dostupná žádná místa.",
-    "errorAlreadyApplied": "Tento student již má přihlášku na tuto příležitost."
+    "errorAlreadyApplied": "Tento student již má přihlášku na tuto příležitost.",
+    "finalListTitle": "Závěrečný seznam Erasmus",
+    "finalListSubtitle": "Vybraní žáci seřazení podle závěrečné známky",
+    "finalListEmpty": "Závěrečný seznam ještě nebyl zveřejněn",
+    "inFinalList": "V závěrečném seznamu",
+    "colPosition": "#",
+    "colName": "Žák",
+    "colCourse": "Kurz",
+    "colGrade": "Známka",
+    "selectCourse": "Všechny kurzy",
+    "errorLoad": "Chyba při načítání závěrečného seznamu"
   },
 
   "documents": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -423,6 +423,7 @@
     "createdAt": "Registered",
     "assignBtn": "Assign to Opportunity",
     "assignToOpportunity": "Assign to Opportunity",
+    "changeOpportunity": "Change Opportunity",
     "selectOpportunity": "Opportunity",
     "selectOpportunityPlaceholder": "Select an opportunity...",
     "noOpportunitiesYet": "No open opportunities available",
@@ -437,7 +438,17 @@
     "errorOpportunityNotFound": "Opportunity not found.",
     "errorOpportunityNotOpen": "This opportunity is not open for applications.",
     "errorNoAvailableSlots": "No available slots for this opportunity.",
-    "errorAlreadyApplied": "This student already has an application for this opportunity."
+    "errorAlreadyApplied": "This student already has an application for this opportunity.",
+    "finalListTitle": "Erasmus Final List",
+    "finalListSubtitle": "Selected students ranked by final grade",
+    "finalListEmpty": "The final list has not been published yet",
+    "inFinalList": "In final list",
+    "colPosition": "#",
+    "colName": "Student",
+    "colCourse": "Course",
+    "colGrade": "Grade",
+    "selectCourse": "All courses",
+    "errorLoad": "Error loading the final list"
   },
 
   "documents": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -423,6 +423,7 @@
     "createdAt": "Fecha de registro",
     "assignBtn": "Asignar a Oportunidad",
     "assignToOpportunity": "Asignar a Oportunidad",
+    "changeOpportunity": "Cambiar Oportunidad",
     "selectOpportunity": "Oportunidad",
     "selectOpportunityPlaceholder": "Selecciona una oportunidad...",
     "noOpportunitiesYet": "No hay oportunidades abiertas",
@@ -437,7 +438,17 @@
     "errorOpportunityNotFound": "Oportunidad no encontrada.",
     "errorOpportunityNotOpen": "Esta oportunidad no está abierta para solicitudes.",
     "errorNoAvailableSlots": "No hay plazas disponibles para esta oportunidad.",
-    "errorAlreadyApplied": "Este alumno ya tiene una solicitud para esta oportunidad."
+    "errorAlreadyApplied": "Este alumno ya tiene una solicitud para esta oportunidad.",
+    "finalListTitle": "Lista Final Erasmus",
+    "finalListSubtitle": "Alumnos seleccionados ordenados por nota final",
+    "finalListEmpty": "La lista final aún no ha sido publicada",
+    "inFinalList": "En lista final",
+    "colPosition": "#",
+    "colName": "Alumno",
+    "colCourse": "Curso",
+    "colGrade": "Nota",
+    "selectCourse": "Todos los cursos",
+    "errorLoad": "Error al cargar la lista final"
   },
 
   "documents": {


### PR DESCRIPTION
Convert students dashboard page to a client component: replace server-side fetching with client hooks (useApi), add pagination, search/course filters, role-based theming, and a new AssignModal to assign/reassign students to opportunities via API. Update UI to show stat cards, final list sorting, and assignment state mapped from applications.

Also: enhance DashboardSidebar to support async toggling of the selection process with a loading state and disabled button while toggling; move confirm handler to a dedicated function and broadcast notifications when starting the process.

Improve OpportunityTable/CreateModal: add a CountryInput autocomplete (country search and flag), better create/edit modal UX, validation for country selection, success/error feedback, a stepper for slots, locale-aware behavior, and various form/state refinements. Update translation JSON files accordingly.

## ✨ Descripción
(Describe brevemente qué añade o corrige este Pull Request.)

## 🔗 Issue relacionado
Fixes #13  
<!-- Ejemplo: Fixes #21 -->

---